### PR TITLE
Bump Netty Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
         <!-- compile dependencies -->
         <aws.java.sdk.version>2.3.5</aws.java.sdk.version>
-        <netty.version>4.1.32.Final</netty.version>
+        <netty.version>[4.1.59.Final,)</netty.version>
         <commons-logging.version>1.2</commons-logging.version>
 
         <!-- test dependencies -->
@@ -103,6 +103,16 @@
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>dynamodb</artifactId>
             <version>${aws.java.sdk.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>software.amazon.awssdk</groupId>


### PR DESCRIPTION
*Issue #, if available:*

Bump Netty version to [4.1.59.Final,) to resolve security vulnerabilities.


#### Testing 


```
mvn clean install -Pintegration-tests

[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------< com.amazonaws:dynamodb-lock-client >-----------------
[INFO] Building Amazon DynamoDB Lock Client 1.2.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ dynamodb-lock-client ---
[INFO] Deleting /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/target
[INFO] 
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce) @ dynamodb-lock-client ---
[INFO] 
[INFO] --- maven-resources-plugin:3.1.0:resources (default-resources) @ dynamodb-lock-client ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/src/main/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.8.0:compile (default-compile) @ dynamodb-lock-client ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 16 source files to /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/target/classes
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.2:instrument (default-instrument) @ dynamodb-lock-client ---
[INFO] 
[INFO] --- maven-resources-plugin:3.1.0:testResources (default-testResources) @ dynamodb-lock-client ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/src/test/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.8.0:testCompile (default-testCompile) @ dynamodb-lock-client ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 16 source files to /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/target/test-classes
[INFO] /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientOptionsTest.java: /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientOptionsTest.java uses or overrides a deprecated API.
[INFO] /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientOptionsTest.java: Recompile with -Xlint:deprecation for details.
[INFO] 
[INFO] --- maven-surefire-plugin:3.0.0-M3:test (default-test) @ dynamodb-lock-client ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.amazonaws.services.dynamodbv2.AmazonDynamoDBLockClientOptionsTest
AmazonDynamoDBLockClientOptionsBuilder(dynamoDBClient=dynamodb, tableName=table, partitionKeyName=customer, sortKeyName=Optional.empty, ownerName=18966ee7-c049-4dd2-9367-8f64bdef2897, leaseDuration=2, heartbeatPeriod=1, timeUnit=SECONDS, createHeartbeatBackgroundThread=true, holdLockOnServiceUnavailable=false)
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 3.443 s - in com.amazonaws.services.dynamodbv2.AmazonDynamoDBLockClientOptionsTest
[INFO] Running com.amazonaws.services.dynamodbv2.CreateDynamoDBTableOptionsTest
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.234 s - in com.amazonaws.services.dynamodbv2.CreateDynamoDBTableOptionsTest
[INFO] Running com.amazonaws.services.dynamodbv2.util.LockClientUtilsTests
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in com.amazonaws.services.dynamodbv2.util.LockClientUtilsTests
[INFO] Running com.amazonaws.services.dynamodbv2.SessionMonitorTest
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.531 s - in com.amazonaws.services.dynamodbv2.SessionMonitorTest
[INFO] Running com.amazonaws.services.dynamodbv2.LockItemTest
[INFO] Tests run: 14, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.06 s - in com.amazonaws.services.dynamodbv2.LockItemTest
[INFO] Running com.amazonaws.services.dynamodbv2.AmazonDynamoDBLockClientTest
Running spied thread
log4j:WARN No appenders could be found for logger (com.amazonaws.services.dynamodbv2.AmazonDynamoDBLockClient).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
[INFO] Tests run: 26, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.084 s - in com.amazonaws.services.dynamodbv2.AmazonDynamoDBLockClientTest
[INFO] Running com.amazonaws.services.dynamodbv2.ReleaseLockOptionsTest
ReleaseLockOptions.ReleaseLockOptionsBuilder(lockItem=LockItem{Partition Key=partitionKey, Sort Key=Optional[sortKey], Owner Name=ownerName, Lookup Time=1000, Lease Duration=1, Record Version Number=recordVersionNumber, Delete On Close=false, Is Released=false}, deleteLock=true, bestEffort=false, data=Optional.empty)
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in com.amazonaws.services.dynamodbv2.ReleaseLockOptionsTest
[INFO] Running com.amazonaws.services.dynamodbv2.model.ExceptionTests
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.amazonaws.services.dynamodbv2.model.ExceptionTests
[INFO] Running com.amazonaws.services.dynamodbv2.LockItemPaginatedScanIteratorTest
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.015 s - in com.amazonaws.services.dynamodbv2.LockItemPaginatedScanIteratorTest
[INFO] Running com.amazonaws.services.dynamodbv2.GetLockOptionsTest
GetLockOptions.GetLockOptionsBuilder(partitionKey=key0, sortKey=Optional[rangeKey0], deleteLockOnRelease=true)
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.amazonaws.services.dynamodbv2.GetLockOptionsTest
[INFO] Running com.amazonaws.services.dynamodbv2.AcquireLockOptionsTest
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.001 s - in com.amazonaws.services.dynamodbv2.AcquireLockOptionsTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 83, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.2:restore-instrumented-classes (default-restore-instrumented-classes) @ dynamodb-lock-client ---
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ dynamodb-lock-client ---
[INFO] Building jar: /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/target/dynamodb-lock-client-1.2.0.jar
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.2:prepare-agent (pre-integration-test) @ dynamodb-lock-client ---
[INFO] failsafeArgLine set to -javaagent:/Users/mokhanxy/.m2/repository/org/jacoco/org.jacoco.agent/0.8.2/org.jacoco.agent-0.8.2-runtime.jar=destfile=/Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/target/coverage-reports/jacoco-it.exec
[INFO] 
[INFO] --- docker-maven-plugin:0.28.0:start (prepare-it-database) @ dynamodb-lock-client ---
[INFO] DOCKER> [amazon/dynamodb-local:1.11.119] "it-database": Start container 378b4f2b8cf7
[INFO] DOCKER> [amazon/dynamodb-local:1.11.119] "it-database": Waiting on url http://localhost:8000/shell/ with method HEAD for status 200..399.
[INFO] DOCKER> [amazon/dynamodb-local:1.11.119] "it-database": Waited on url http://localhost:8000/shell/ 1235 ms
[INFO] 
[INFO] --- maven-failsafe-plugin:3.0.0-M3:integration-test (default-integration-tests) @ dynamodb-lock-client ---
[INFO] 
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.amazonaws.services.dynamodbv2.GetAllLocksTests
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
log4j:WARN No appenders could be found for logger (org.apache.http.client.protocol.RequestAddCookies).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Random seed is 1616553835879
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.208 s - in com.amazonaws.services.dynamodbv2.GetAllLocksTests
[INFO] Running com.amazonaws.services.dynamodbv2.BasicLockClientTests
[INFO] Tests run: 97, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 116.029 s - in com.amazonaws.services.dynamodbv2.BasicLockClientTests
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 101, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.2:report (post-integration-test) @ dynamodb-lock-client ---
[INFO] Skipping JaCoCo execution due to missing execution data file.
[INFO] 
[INFO] --- docker-maven-plugin:0.28.0:stop (remove-it-database) @ dynamodb-lock-client ---
[INFO] DOCKER> [amazon/dynamodb-local:1.11.119] "it-database": Stop and removed container 378b4f2b8cf7 after 0 ms
[INFO] 
[INFO] >>> spotbugs-maven-plugin:3.1.10:check (default) > :spotbugs @ dynamodb-lock-client >>>
[INFO] 
[INFO] --- spotbugs-maven-plugin:3.1.10:spotbugs (spotbugs) @ dynamodb-lock-client ---
[INFO] Fork Value is true
[INFO] Done SpotBugs Analysis....
[INFO] 
[INFO] <<< spotbugs-maven-plugin:3.1.10:check (default) < :spotbugs @ dynamodb-lock-client <<<
[INFO] 
[INFO] 
[INFO] --- spotbugs-maven-plugin:3.1.10:check (default) @ dynamodb-lock-client ---
[INFO] BugInstance size is 0
[INFO] Error size is 0
[INFO] No errors/warnings found
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.2:report (default-report) @ dynamodb-lock-client ---
[INFO] Skipping JaCoCo execution due to missing execution data file.
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.2:check (check) @ dynamodb-lock-client ---
[INFO] Skipping JaCoCo execution due to missing execution data file:/Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/target/coverage-reports/aggregate.exec
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.2:merge (merge-results) @ dynamodb-lock-client ---
[INFO] Loading execution data file /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/target/coverage-reports/jacoco-ut.exec
[INFO] Writing merged execution data to /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/target/coverage-reports/aggregate.exec
[INFO] 
[INFO] --- jacoco-maven-plugin:0.8.2:report (post-merge-report) @ dynamodb-lock-client ---
[INFO] Loading execution data file /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/target/coverage-reports/aggregate.exec
[INFO] Analyzed bundle 'Amazon DynamoDB Lock Client' with 21 classes
[INFO] 
[INFO] >>> maven-pmd-plugin:3.8:check (default) > :pmd @ dynamodb-lock-client >>>
[INFO] 
[INFO] --- maven-pmd-plugin:3.8:pmd (pmd) @ dynamodb-lock-client ---
[WARNING] Unable to locate Source XRef to link to - DISABLED
[WARNING] Unable to locate Source XRef to link to - DISABLED
[INFO] 
[INFO] <<< maven-pmd-plugin:3.8:check (default) < :pmd @ dynamodb-lock-client <<<
[INFO] 
[INFO] 
[INFO] --- maven-pmd-plugin:3.8:check (default) @ dynamodb-lock-client ---
[INFO] 
[INFO] 
[INFO] >>> maven-pmd-plugin:3.8:cpd-check (default) > :cpd @ dynamodb-lock-client >>>
[INFO] 
[INFO] --- maven-pmd-plugin:3.8:cpd (cpd) @ dynamodb-lock-client ---
[WARNING] Unable to locate Source XRef to link to - DISABLED
[WARNING] Unable to locate Source XRef to link to - DISABLED
[INFO] 
[INFO] <<< maven-pmd-plugin:3.8:cpd-check (default) < :cpd @ dynamodb-lock-client <<<
[INFO] 
[INFO] 
[INFO] --- maven-pmd-plugin:3.8:cpd-check (default) @ dynamodb-lock-client ---
[INFO] 
[INFO] 
[INFO] --- maven-dependency-plugin:3.1.1:analyze-only (analyze) @ dynamodb-lock-client ---
[INFO] No dependency problems found
[INFO] 
[INFO] --- maven-failsafe-plugin:3.0.0-M3:verify (default-integration-tests) @ dynamodb-lock-client ---
[INFO] 
[INFO] --- maven-install-plugin:2.4:install (default-install) @ dynamodb-lock-client ---
[INFO] Installing /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/target/dynamodb-lock-client-1.2.0.jar to /Users/mokhanxy/.m2/repository/com/amazonaws/dynamodb-lock-client/1.2.0/dynamodb-lock-client-1.2.0.jar
[INFO] Installing /Volumes/workplace/ddblockclient/amazon-dynamodb-lock-client/pom.xml to /Users/mokhanxy/.m2/repository/com/amazonaws/dynamodb-lock-client/1.2.0/dynamodb-lock-client-1.2.0.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:27 min
[INFO] Finished at: 2021-03-23T19:46:00-07:00
[INFO] ------------------------------------------------------------------------

```