### PR TITLE
Sync local lockItem with dynamodb after `sendHeartbeat(options)` changes the data

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
@@ -1141,11 +1141,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
                 final long lastUpdateOfLock = LockClientUtils.INSTANCE.millisecondTime();
                 this.dynamoDB.updateItem(updateItemRequest);
                 lockItem.updateRecordVersionNumber(recordVersionNumber, lastUpdateOfLock, leaseDurationToEnsureInMilliseconds);
-                if (deleteData) {
-                    lockItem.updateData(null);
-                } else if (options.getData().isPresent()) {
-                    lockItem.updateData(options.getData().get());
-                }
+                lockItem.updateData(options.getData().orElse(null));
             } catch (final ConditionalCheckFailedException conditionalCheckFailedException) {
                 logger.debug("Someone else acquired the lock, so we will stop heartbeating it", conditionalCheckFailedException);
                 this.locks.remove(lockItem.getUniqueIdentifier());

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
@@ -1141,6 +1141,11 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
                 final long lastUpdateOfLock = LockClientUtils.INSTANCE.millisecondTime();
                 this.dynamoDB.updateItem(updateItemRequest);
                 lockItem.updateRecordVersionNumber(recordVersionNumber, lastUpdateOfLock, leaseDurationToEnsureInMilliseconds);
+                if (deleteData) {
+                    lockItem.updateData(null);
+                } else if (options.getData().isPresent()) {
+                    lockItem.updateData(options.getData().get());
+                }
             } catch (final ConditionalCheckFailedException conditionalCheckFailedException) {
                 logger.debug("Someone else acquired the lock, so we will stop heartbeating it", conditionalCheckFailedException);
                 this.locks.remove(lockItem.getUniqueIdentifier());

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
@@ -1141,7 +1141,11 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
                 final long lastUpdateOfLock = LockClientUtils.INSTANCE.millisecondTime();
                 this.dynamoDB.updateItem(updateItemRequest);
                 lockItem.updateRecordVersionNumber(recordVersionNumber, lastUpdateOfLock, leaseDurationToEnsureInMilliseconds);
-                lockItem.updateData(options.getData().orElse(null));
+                if (deleteData) {
+                    lockItem.updateData(null);
+                } else if (options.getData().isPresent()) {
+                    lockItem.updateData(options.getData().get());
+                }
             } catch (final ConditionalCheckFailedException conditionalCheckFailedException) {
                 logger.debug("Someone else acquired the lock, so we will stop heartbeating it", conditionalCheckFailedException);
                 this.locks.remove(lockItem.getUniqueIdentifier());

--- a/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
@@ -39,7 +39,7 @@ public class LockItem implements Closeable {
     private final String partitionKey;
     private final Optional<String> sortKey;
 
-    private final AtomicReference<ByteBuffer> data;
+    private ByteBuffer data;
     private final String ownerName;
     private final boolean deleteLockItemOnClose;
     private final boolean isReleased;
@@ -84,7 +84,7 @@ public class LockItem implements Closeable {
         this.client = client;
         this.partitionKey = partitionKey;
         this.sortKey = sortKey;
-        this.data = new AtomicReference<>(data.orElse(null));
+        this.data = data.orElse(null);
         this.ownerName = ownerName;
         this.deleteLockItemOnClose = deleteLockItemOnClose;
 
@@ -119,7 +119,7 @@ public class LockItem implements Closeable {
      * @return Returns the data associated with the lock, which is optional.
      */
     public Optional<ByteBuffer> getData() {
-        return Optional.ofNullable(this.data.get());
+        return Optional.ofNullable(data);
     }
 
     /**
@@ -194,9 +194,10 @@ public class LockItem implements Closeable {
     @Override
     public String toString() {
         return String
-            .format("LockItem{Partition Key=%s, Sort Key=%s, Owner Name=%s, Lookup Time=%d, Lease Duration=%d, " + "Record Version Number=%s, Delete On Close=%s, Is Released=%s}",
+            .format("LockItem{Partition Key=%s, Sort Key=%s, Owner Name=%s, Lookup Time=%d, Lease Duration=%d, "
+                    + "Record Version Number=%s, Delete On Close=%s, Data=%s, Is Released=%s}",
                 this.partitionKey, this.sortKey, this.ownerName, this.lookupTime.get(), this.leaseDuration.get(), this.recordVersionNumber, this.deleteLockItemOnClose,
-                this.isReleased);
+                this.data, this.isReleased);
     }
 
     /**
@@ -300,7 +301,7 @@ public class LockItem implements Closeable {
      * client.
      */
     void updateData(ByteBuffer byteBuffer) {
-        this.data.set(byteBuffer);
+        this.data = byteBuffer;
     }
 
     /**

--- a/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
@@ -1047,7 +1047,8 @@ public class BasicLockClientTests extends InMemoryLockClientTester {
         this.lockClient.sendHeartbeat(SendHeartbeatOptions.builder(item).withData(ByteBuffer.wrap(data2.getBytes())).build());
         assertEquals(data2, byteBufferToString(this.lockClient.getLockFromDynamoDB(
                 GetLockOptions.builder("testKey1").build()).get().getData().get()));
-
+        assertEquals(data2, byteBufferToString(this.lockClient.getLock(
+            "testKey1", Optional.empty()).get().getData().get()));
         item.close();
     }
 
@@ -1063,7 +1064,7 @@ public class BasicLockClientTests extends InMemoryLockClientTester {
         assertEquals(data, byteBufferToString(this.lockClient.getLockFromDynamoDB(GET_LOCK_OPTIONS_DELETE_ON_RELEASE).get().getData().get()));
         this.lockClient.sendHeartbeat(SendHeartbeatOptions.builder(item).withDeleteData(true).build());
         assertEquals(Optional.empty(), this.lockClient.getLockFromDynamoDB(GET_LOCK_OPTIONS_DELETE_ON_RELEASE).get().getData());
-
+        assertEquals(Optional.empty(), this.lockClient.getLock("testKey1", Optional.empty()).get().getData());
         item.close();
     }
 

--- a/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
@@ -14,9 +14,12 @@
  */
 package com.amazonaws.services.dynamodbv2;
 
+import com.amazonaws.services.dynamodbv2.model.LockNotGrantedException;
+import com.amazonaws.services.dynamodbv2.model.LockTableDoesNotExistException;
+import com.amazonaws.services.dynamodbv2.model.SessionMonitorNotSetException;
+import com.amazonaws.services.dynamodbv2.util.LockClientUtils;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -24,17 +27,10 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
-
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
-
-import com.amazonaws.services.dynamodbv2.model.LockNotGrantedException;
-import com.amazonaws.services.dynamodbv2.model.LockTableDoesNotExistException;
-import com.amazonaws.services.dynamodbv2.model.SessionMonitorNotSetException;
-import com.amazonaws.services.dynamodbv2.util.LockClientUtils;
-import org.powermock.api.mockito.PowerMockito;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -1475,7 +1471,7 @@ public class BasicLockClientTests extends InMemoryLockClientTester {
     public void testLockItemToString() throws LockNotGrantedException, InterruptedException {
         final LockItem lockItem = this.lockClient.acquireLock(ACQUIRE_LOCK_OPTIONS_TEST_KEY_1);
         final Pattern p = Pattern.compile("LockItem\\{Partition Key=testKey1, Sort Key=Optional.empty, Owner Name=" + INTEGRATION_TESTER + ", Lookup Time=\\d+, Lease Duration=3000, "
-            + "Record Version Number=\\w+-\\w+-\\w+-\\w+-\\w+, Delete On Close=true, Is Released=false\\}");
+            + "Record Version Number=\\w+-\\w+-\\w+-\\w+-\\w+, Delete On Close=true, Data=" + TEST_DATA + ", Is Released=false\\}");
         assertTrue(p.matcher(lockItem.toString()).matches());
     }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-dynamodb-lock-client/issues/54

*Description of changes:*

Make `LockItem`'s `data` field an AtomicReference so that a new method `updateData()` can update it. If `sendHeartbeat(options)` successfully updates or removes the data in dynamodb, the lockItem's `updateData()` method is called to sync the data with dynamodb.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
