### PR TITLE
Add reentrant option for acquireLock()

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/AcquireLockOptions.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AcquireLockOptions.java
@@ -459,7 +459,8 @@ public class AcquireLockOptions {
                 && Objects.equals(this.sessionMonitor, otherOptions.sessionMonitor)
                 && Objects.equals(this.updateExistingLockRecord, otherOptions.updateExistingLockRecord)
                 && Objects.equals(this.shouldSkipBlockingWait, otherOptions.shouldSkipBlockingWait)
-                && Objects.equals(this.acquireReleasedLocksConsistently, otherOptions.acquireReleasedLocksConsistently);
+                && Objects.equals(this.acquireReleasedLocksConsistently, otherOptions.acquireReleasedLocksConsistently)
+                && Objects.equals(this.reentrant, otherOptions.reentrant);
     }
 
     @Override
@@ -467,7 +468,7 @@ public class AcquireLockOptions {
         return Objects.hash(this.partitionKey, this.sortKey, this.data, this.replaceData, this.deleteLockOnRelease,
                 this.acquireOnlyIfLockAlreadyExists, this.refreshPeriod, this.additionalTimeToWaitForLock, this.timeUnit,
                 this.additionalAttributes, this.sessionMonitor, this.updateExistingLockRecord,
-                this.shouldSkipBlockingWait, this.acquireReleasedLocksConsistently);
+                this.shouldSkipBlockingWait, this.acquireReleasedLocksConsistently, this.reentrant);
 
     }
 

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AcquireLockOptions.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AcquireLockOptions.java
@@ -333,7 +333,7 @@ public class AcquireLockOptions {
             }
             return new AcquireLockOptions(this.partitionKey, this.sortKey, this.data, this.replaceData, this.deleteLockOnRelease, this.acquireOnlyIfLockAlreadyExists,
                     this.refreshPeriod, this.additionalTimeToWaitForLock, this.timeUnit, this.additionalAttributes, sessionMonitor,
-                    this.updateExistingLockRecord, this.shouldSkipBlockingWait, this.acquireReleasedLocksConsistently, reentrant);
+                    this.updateExistingLockRecord, this.shouldSkipBlockingWait, this.acquireReleasedLocksConsistently, this.reentrant);
         }
 
         @Override
@@ -341,7 +341,8 @@ public class AcquireLockOptions {
             return "AcquireLockOptions.AcquireLockOptionsBuilder(key=" + this.partitionKey + ", sortKey=" + this.sortKey + ", data=" + this.data + ", replaceData="
                 + this.replaceData + ", deleteLockOnRelease=" + this.deleteLockOnRelease + ", refreshPeriod=" + this.refreshPeriod + ", additionalTimeToWaitForLock="
                 + this.additionalTimeToWaitForLock + ", timeUnit=" + this.timeUnit + ", additionalAttributes=" + this.additionalAttributes + ", safeTimeWithoutHeartbeat="
-                + this.safeTimeWithoutHeartbeat + ", sessionMonitorCallback=" + this.sessionMonitorCallback + ", acquireReleasedLocksConsistently=" + this.acquireReleasedLocksConsistently + ")";
+                + this.safeTimeWithoutHeartbeat + ", sessionMonitorCallback=" + this.sessionMonitorCallback + ", acquireReleasedLocksConsistently="
+                + this.acquireReleasedLocksConsistently + ", reentrant=" + this.reentrant+ ")";
         }
     }
 

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AcquireLockOptions.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AcquireLockOptions.java
@@ -44,6 +44,7 @@ public class AcquireLockOptions {
     private final Boolean updateExistingLockRecord;
     private final Boolean acquireReleasedLocksConsistently;
     private final Optional<SessionMonitor> sessionMonitor;
+    private final Boolean reentrant;
 
     /**
      * Setting this flag to true will prevent the thread from being blocked (put to sleep) for the lease duration and
@@ -70,6 +71,7 @@ public class AcquireLockOptions {
         private Map<String, AttributeValue> additionalAttributes;
         private Boolean updateExistingLockRecord;
         private Boolean acquireReleasedLocksConsistently;
+        private Boolean reentrant;
 
         private long safeTimeWithoutHeartbeat;
         private Optional<Runnable> sessionMonitorCallback;
@@ -87,6 +89,7 @@ public class AcquireLockOptions {
             this.updateExistingLockRecord = false;
             this.shouldSkipBlockingWait = false;
             this.acquireReleasedLocksConsistently = false;
+            this.reentrant = false;
         }
 
         /**
@@ -241,6 +244,19 @@ public class AcquireLockOptions {
         }
 
         /**
+         * With this set to true, the lock client will check first if it already owns the lock. If it already owns the lock and the
+         * lock is not expired, it will return the lock immediately. If this is set to false and the client already owns the lock,
+         * the call to acquireLock will block.
+         *
+         * @param reentrant whether the lock client should not block if it already owns the lock
+         * @return a reference to this builder for fluent method chaining
+         */
+        public AcquireLockOptionsBuilder withReentrant(final boolean reentrant) {
+            this.reentrant = reentrant;
+            return this;
+        }
+
+        /**
          * <p>
          * Registers a "SessionMonitor."
          * </p>
@@ -317,7 +333,7 @@ public class AcquireLockOptions {
             }
             return new AcquireLockOptions(this.partitionKey, this.sortKey, this.data, this.replaceData, this.deleteLockOnRelease, this.acquireOnlyIfLockAlreadyExists,
                     this.refreshPeriod, this.additionalTimeToWaitForLock, this.timeUnit, this.additionalAttributes, sessionMonitor,
-                    this.updateExistingLockRecord, this.shouldSkipBlockingWait, this.acquireReleasedLocksConsistently);
+                    this.updateExistingLockRecord, this.shouldSkipBlockingWait, this.acquireReleasedLocksConsistently, reentrant);
         }
 
         @Override
@@ -343,7 +359,7 @@ public class AcquireLockOptions {
     private AcquireLockOptions(final String partitionKey, final Optional<String> sortKey, final Optional<ByteBuffer> data, final Boolean replaceData,
        final Boolean deleteLockOnRelease, final Boolean acquireOnlyIfLockAlreadyExists, final Long refreshPeriod, final Long additionalTimeToWaitForLock,
        final TimeUnit timeUnit, final Map<String, AttributeValue> additionalAttributes, final Optional<SessionMonitor> sessionMonitor,
-       final Boolean updateExistingLockRecord, final Boolean shouldSkipBlockingWait, final Boolean acquireReleasedLocksConsistently) {
+       final Boolean updateExistingLockRecord, final Boolean shouldSkipBlockingWait, final Boolean acquireReleasedLocksConsistently, Boolean reentrant) {
        this.partitionKey = partitionKey;
        this.sortKey = sortKey;
        this.data = data;
@@ -358,7 +374,8 @@ public class AcquireLockOptions {
        this.updateExistingLockRecord = updateExistingLockRecord;
        this.shouldSkipBlockingWait = shouldSkipBlockingWait;
        this.acquireReleasedLocksConsistently = acquireReleasedLocksConsistently;
-   }
+       this.reentrant = reentrant;
+    }
 
     String getPartitionKey() {
         return this.partitionKey;
@@ -400,6 +417,10 @@ public class AcquireLockOptions {
 
     TimeUnit getTimeUnit() {
         return this.timeUnit;
+    }
+
+    Boolean getReentrant() {
+      return this.reentrant;
     }
 
     Map<String, AttributeValue> getAdditionalAttributes() {

--- a/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
@@ -17,6 +17,7 @@ package com.amazonaws.services.dynamodbv2;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
 import static org.powermock.api.mockito.PowerMockito.spy;
@@ -264,6 +265,40 @@ public class AmazonDynamoDBLockClientTest {
             .withReentrant(true).build());
         assertNotNull(lockItem2);
         assertEquals(partitionKey, lockItem2.getPartitionKey());
+    }
+
+    @Test
+    public void acquireLock_withReentrantFalse_failsIfHoldingLock() throws InterruptedException {
+        UUID uuid = setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        Map<String, AttributeValue> item = new HashMap<>(5);
+        item.put("customer", AttributeValue.builder().s("customer1").build());
+        item.put("ownerName", AttributeValue.builder().s("foobar").build());
+        item.put("recordVersionNumber", AttributeValue.builder().s(uuid.toString()).build());
+        item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        // Use different rvns to simulate heartbeat.
+        Map<String, AttributeValue> differentRvn1 = new HashMap<>(item);
+        differentRvn1.put("recordVersionNumber",
+            AttributeValue.builder().s("uuid1").build());
+        Map<String, AttributeValue> differentRvn2 = new HashMap<>(item);
+        differentRvn2.put("recordVersionNumber",
+            AttributeValue.builder().s("uuid2").build());
+        when(dynamodb.getItem(Mockito.<GetItemRequest>any()))
+            .thenReturn(GetItemResponse.builder().item(item).build())
+            .thenReturn(GetItemResponse.builder().item(item).build())
+            .thenReturn(GetItemResponse.builder().item(differentRvn1).build())
+            .thenReturn(GetItemResponse.builder().item(differentRvn2).build());
+        String partitionKey = "asdf";
+        LockItem lockItem1 = client.acquireLock(AcquireLockOptions.builder(partitionKey).build());
+        assertNotNull(lockItem1);
+        assertEquals(partitionKey, lockItem1.getPartitionKey());
+
+        try {
+            client.acquireLock(AcquireLockOptions.builder(partitionKey).build());
+            fail("Expected acquireLock to throw.");
+        } catch (LockNotGrantedException e) {
+            assertTrue(e.getMessage().contains("Didn't acquire lock after sleeping for"));
+        }
     }
 
     @Test

--- a/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
@@ -990,6 +990,21 @@ public class BasicLockClientTests extends InMemoryLockClientTester {
         item.close();
     }
 
+    @Test(expected = LockNotGrantedException.class)
+    public void testAcquireLockMultipleTimesNotReentrant() throws InterruptedException {
+        LockItem item = this.lockClientWithHeartbeating.acquireLock(AcquireLockOptions.builder("testKey1").build());
+        item = this.lockClientWithHeartbeating.acquireLock(AcquireLockOptions.builder("testKey1").build());
+        item.close();
+    }
+
+    @Test
+    public void testAcquireLockMultipleTimesReentrant() throws InterruptedException {
+        LockItem item = this.lockClientWithHeartbeating.acquireLock(AcquireLockOptions.builder("testKey1").build());
+        item = this.lockClientWithHeartbeating.acquireLock(AcquireLockOptions.builder("testKey1")
+            .withReentrant(true).build());
+        item.close();
+    }
+
     @Test
     public void testSendHeatbeatWithRangeKey() throws IOException, LockNotGrantedException, InterruptedException {
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/amazon-dynamodb-lock-client/issues/56

*Description of changes:*

Add a reentrant option for acquireLock(). With this set to true, the lock client will check first if it already owns the lock. If it already owns the lock and the lock is not expired, it will return the lock immediately. If this is set to false and the client already owns the lock, the call to acquireLock will block.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
