### PR TITLE
Add getLocksByPartitionKey()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <maven.failsafe.version>3.0.0-M3</maven.failsafe.version>
         <docker.maven.plugin.version>0.28.0</docker.maven.plugin.version>
         <build.profile.id>dev</build.profile.id>
-        <integration-test.category>*/BasicLockClientTests.java,*/GetAllLocksTests.java,*/ConsistentLockDataStressTest.java</integration-test.category>
+        <integration-test.category>*/BasicLockClientTests.java,*/GetAllLocksTests.java,*/GetLocksByPartitionKeyTest.java,*/ConsistentLockDataStressTest.java</integration-test.category>
 
         <!-- code quality tools -->
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
@@ -541,6 +541,7 @@
                                     <includes>
                                         <include>*/BasicLockClientTests.java</include>
                                         <include>*/GetAllLocksTests.java</include>
+                                        <include>*/GetLocksByPartitionKeyTest.java</include>
                                     </includes>
                                     <skip>false</skip>
                                     <systemPropertyVariables>

--- a/src/main/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedIterator.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedIterator.java
@@ -1,0 +1,43 @@
+package com.amazonaws.services.dynamodbv2;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public abstract class LockItemPaginatedIterator implements Iterator<LockItem> {
+  protected List<LockItem> currentPageResults = Collections.emptyList();
+  protected int currentPageResultsIndex = 0;
+
+  @Override
+  public boolean hasNext() {
+    while (this.currentPageResultsIndex == this.currentPageResults.size() && this.hasAnotherPageToLoad()) {
+      this.loadNextPageIntoResults();
+    }
+
+    return this.currentPageResultsIndex < this.currentPageResults.size();
+  }
+
+  @Override
+  public LockItem next() throws NoSuchElementException {
+    if (!this.hasNext()) {
+      throw new NoSuchElementException();
+    }
+
+    final LockItem next = this.currentPageResults.get(this.currentPageResultsIndex);
+    this.currentPageResultsIndex++;
+
+    return next;
+  }
+
+  @Override
+  public void remove() throws UnsupportedOperationException {
+    throw new UnsupportedOperationException("This iterator is immutable.");
+  }
+
+  protected abstract boolean hasAnotherPageToLoad();
+
+  protected abstract boolean hasLoadedFirstPage();
+
+  protected abstract void loadNextPageIntoResults();
+}

--- a/src/main/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedIterator.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedIterator.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * <p>
+ * http://aws.amazon.com/asl/
+ * <p>
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.amazonaws.services.dynamodbv2;
 
 import java.util.Collections;
@@ -5,6 +19,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+/**
+ * Paginated iterator for lock items.
+ */
 public abstract class LockItemPaginatedIterator implements Iterator<LockItem> {
   protected List<LockItem> currentPageResults = Collections.emptyList();
   protected int currentPageResultsIndex = 0;

--- a/src/main/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedQueryIterator.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedQueryIterator.java
@@ -1,0 +1,58 @@
+package com.amazonaws.services.dynamodbv2;
+
+import java.util.Objects;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Lazy-loaded. Not immutable. Not thread safe.
+ */
+final class LockItemPaginatedQueryIterator extends LockItemPaginatedIterator {
+  private final DynamoDbClient dynamoDB;
+  private volatile QueryRequest queryRequest;
+  private final LockItemFactory lockItemFactory;
+
+  /**
+   * Initially null to indicate that no pages have been loaded yet.
+   * Afterwards, its {@link QueryResponse#lastEvaluatedKey()} is used to tell
+   * if there are more pages to load if its
+   * {@link QueryResponse#lastEvaluatedKey()} is not null.
+   */
+  private volatile QueryResponse queryResponse = null;
+
+  LockItemPaginatedQueryIterator(final DynamoDbClient dynamoDB, final QueryRequest queryRequest, final LockItemFactory lockItemFactory) {
+    this.dynamoDB = Objects.requireNonNull(dynamoDB, "dynamoDB must not be null");
+    this.queryRequest = Objects.requireNonNull(queryRequest, "queryRequest must not be null");
+    this.lockItemFactory = Objects.requireNonNull(lockItemFactory, "lockItemFactory must not be null");
+  }
+
+  protected boolean hasAnotherPageToLoad() {
+    if (!this.hasLoadedFirstPage()) {
+      return true;
+    }
+
+    return this.queryResponse.lastEvaluatedKey() != null && !this.queryResponse.lastEvaluatedKey().isEmpty();
+  }
+
+  protected boolean hasLoadedFirstPage() {
+    return this.queryResponse != null;
+  }
+
+  protected void loadNextPageIntoResults() {
+    this.queryResponse = this.dynamoDB.query(this.queryRequest);
+
+    this.currentPageResults = this.queryResponse.items().stream().map(this.lockItemFactory::create).collect(toList());
+    this.currentPageResultsIndex = 0;
+
+    this.queryRequest = QueryRequest.builder()
+        .tableName(queryRequest.tableName())
+        .keyConditionExpression(queryRequest.keyConditionExpression())
+        .expressionAttributeNames(queryRequest.expressionAttributeNames())
+        .expressionAttributeValues(queryRequest.expressionAttributeValues())
+        .exclusiveStartKey(queryResponse.lastEvaluatedKey())
+        .build();
+  }
+}

--- a/src/main/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedQueryIterator.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedQueryIterator.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * <p>
+ * http://aws.amazon.com/asl/
+ * <p>
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.amazonaws.services.dynamodbv2;
 
 import java.util.Objects;

--- a/src/test/java/com/amazonaws/services/dynamodbv2/GetLocksByPartitionKeyTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/GetLocksByPartitionKeyTest.java
@@ -1,0 +1,175 @@
+package com.amazonaws.services.dynamodbv2;
+
+import com.amazonaws.services.dynamodbv2.model.LockNotGrantedException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.Test;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GetLocksByPartitionKeyTest extends InMemoryLockClientTester {
+  /**
+   * <p>1 MB</p>
+   * <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Pagination">
+   * Dynamo DB Max Page Size Documentation
+   * </a>
+   */
+  private static final int DYNAMODB_MAX_PAGE_SIZE_IN_BYTES = 1 << 20;
+
+  /**
+   * <p>400 KB</p>
+   * <a href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/WorkingWithItems.html#WorkingWithItems.BatchOperations">
+   * Dynamo DB Max Item Size Documentation
+   * </a>
+   */
+  private static final int DYNAMODB_MAX_ITEM_SIZE_IN_BYTES = 400 * (1 << 10);
+
+  @Test
+  public void getLocksFromDynamoDB_whenNoLocks_shouldReturnEmpty() throws LockNotGrantedException {
+    final boolean deleteOnRelease = false;
+    final List<LockItem>
+        locksWithPartitionKey = this.lockClientForRangeKeyTable.getLocksByPartitionKey("test", deleteOnRelease).collect(toList());
+
+    assertEquals(Collections.emptyList(), locksWithPartitionKey);
+  }
+
+  @Test
+  public void getLocksFromDynamoDB_whenSingleLock_shouldReturnSingleLock() throws LockNotGrantedException, InterruptedException {
+    final String partitionKey = "Test 1";
+    final String sortKey = "1";
+    final AcquireLockOptions options = AcquireLockOptions.builder(partitionKey)
+        .withSortKey(sortKey).withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withDeleteLockOnRelease(true).build();
+
+    final LockItem singleLock = this.lockClientForRangeKeyTable.acquireLock(options);
+
+    final boolean deleteOnRelease = false;
+    List<LockItem> locksWithParitionKey = this.lockClientForRangeKeyTable.getLocksByPartitionKey(partitionKey, deleteOnRelease).collect(toList());
+
+    assertEquals(1, locksWithParitionKey.size());
+
+    final LockItem retrievedLock = locksWithParitionKey.get(0);
+    assertEquals(singleLock.getPartitionKey(), retrievedLock.getPartitionKey());
+    assertEquals(singleLock.getSortKey(), retrievedLock.getSortKey());
+    assertTrue(
+        Arrays.equals(getBytes(singleLock.getData().get()), getBytes(retrievedLock.getData().get())));
+    assertEquals(singleLock.getRecordVersionNumber(), retrievedLock.getRecordVersionNumber());
+
+    this.lockClientForRangeKeyTable.getLock(partitionKey, Optional.of(sortKey)).get().close();
+
+    locksWithParitionKey = this.lockClientForRangeKeyTable.getLocksByPartitionKey(partitionKey, deleteOnRelease).collect(toList());
+    assertEquals(Collections.emptyList(), locksWithParitionKey);
+  }
+
+  @Test
+  public void getLocksFromDynamoDB_whenMultipleLocks_shouldReturnMultipleLocks() throws LockNotGrantedException, InterruptedException, IOException {
+    final String partitionKey = "Test 1";
+    final AcquireLockOptions options1 = AcquireLockOptions.builder(partitionKey)
+        .withSortKey("1").withData(ByteBuffer.wrap(TEST_DATA.getBytes())).withDeleteLockOnRelease(true).build();
+    final LockItem firstLock = this.lockClientForRangeKeyTable.acquireLock(options1);
+
+    final AcquireLockOptions options2 = AcquireLockOptions.builder(partitionKey)
+        .withSortKey("2").withData(ByteBuffer.wrap((TEST_DATA + "differentBytes").getBytes())).withDeleteLockOnRelease(true).build();
+    final LockItem secondLock = this.lockClientForRangeKeyTable.acquireLock(options2);
+
+    final boolean deleteOnRelease = false;
+    List<LockItem> allLocksFromDynamoDB = this.lockClientForRangeKeyTable.getLocksByPartitionKey(partitionKey, deleteOnRelease).collect(toList());
+
+    assertEquals(2, allLocksFromDynamoDB.size());
+
+    final Map<String, LockItem> lockItemsByKey = toLockItemsByKey(allLocksFromDynamoDB);
+
+    LockItem retrievedLock = lockItemsByKey.get(getLockKey(firstLock));
+    assertEquals(firstLock.getPartitionKey(), retrievedLock.getPartitionKey());
+    assertEquals(firstLock.getSortKey(), retrievedLock.getSortKey());
+    assertTrue(Arrays.equals(getBytes(firstLock.getData().get()), getBytes(retrievedLock.getData().get())));
+    assertEquals(firstLock.getRecordVersionNumber(), retrievedLock.getRecordVersionNumber());
+
+    retrievedLock = lockItemsByKey.get(getLockKey(secondLock));
+    assertEquals(secondLock.getPartitionKey(), retrievedLock.getPartitionKey());
+    assertEquals(secondLock.getSortKey(), retrievedLock.getSortKey());
+    assertTrue(Arrays.equals(getBytes(secondLock.getData().get()), getBytes(retrievedLock.getData().get())));
+    assertEquals(secondLock.getRecordVersionNumber(), retrievedLock.getRecordVersionNumber());
+
+    firstLock.close();
+
+    allLocksFromDynamoDB = this.lockClientForRangeKeyTable.getLocksByPartitionKey(partitionKey, deleteOnRelease).collect(toList());
+
+    assertEquals(1, allLocksFromDynamoDB.size());
+    retrievedLock = allLocksFromDynamoDB.get(0);
+    assertEquals(secondLock.getPartitionKey(), retrievedLock.getPartitionKey());
+    assertEquals(secondLock.getSortKey(), retrievedLock.getSortKey());
+    assertTrue(Arrays.equals(getBytes(secondLock.getData().get()), getBytes(retrievedLock.getData().get())));
+    assertEquals(secondLock.getRecordVersionNumber(), retrievedLock.getRecordVersionNumber());
+
+    secondLock.close();
+
+    allLocksFromDynamoDB = this.lockClientForRangeKeyTable.getLocksByPartitionKey(partitionKey, deleteOnRelease).collect(toList());
+    assertEquals(Collections.emptyList(), allLocksFromDynamoDB);
+  }
+
+  @Test
+  public void getLocksFromDynamoDB_whenMultiplePages_shouldReturnMultiplePages() throws LockNotGrantedException, InterruptedException, IOException {
+    // Scan is paginated.
+    // Scans with items that are larger than 1MB are paginated
+    // and must be retrieved by performing multiple scans.
+    // Make sure the client handles pagination correctly.
+    // See
+    // http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Pagination
+    final String partitionKey = "Test 1";
+    int numBytesOfData = 0;
+    final byte[] data = new byte[(DYNAMODB_MAX_ITEM_SIZE_IN_BYTES * 9) / 10];
+    final long randomSeed = System.currentTimeMillis();
+    System.out.println("Random seed is " + randomSeed);
+    final Map<String, LockItem> acquiredLockItemsByKey = new HashMap<>();
+    while (numBytesOfData < DYNAMODB_MAX_PAGE_SIZE_IN_BYTES) {
+      SECURE_RANDOM.nextBytes(data);
+      int size = acquiredLockItemsByKey.size();
+      final AcquireLockOptions options =
+          AcquireLockOptions.builder(partitionKey)
+              .withSortKey(Integer.toString(size))
+              .withData(ByteBuffer.wrap(data)).withDeleteLockOnRelease(true).build();
+      final LockItem acquiredLock = this.lockClientForRangeKeyTable.acquireLock(options);
+
+      acquiredLockItemsByKey.put(getLockKey(acquiredLock), acquiredLock);
+      numBytesOfData += acquiredLock.getData().get().array().length;
+    }
+
+    final boolean deleteOnRelease = false;
+    List<LockItem> locksWithPartitionKey = this.lockClientForRangeKeyTable.getLocksByPartitionKey(partitionKey, deleteOnRelease).collect(toList());
+
+    assertEquals(acquiredLockItemsByKey.size(), locksWithPartitionKey.size());
+
+    final Map<String, LockItem> lockItemsByKey = toLockItemsByKey(locksWithPartitionKey);
+
+    assertEquals(acquiredLockItemsByKey.keySet(), lockItemsByKey.keySet());
+
+    for (final LockItem acquiredLock : acquiredLockItemsByKey.values()) {
+      acquiredLock.close();
+    }
+
+    locksWithPartitionKey = this.lockClientForRangeKeyTable.getLocksByPartitionKey(partitionKey, deleteOnRelease).collect(toList());
+    assertEquals(Collections.emptyList(), locksWithPartitionKey);
+  }
+
+  private static Map<String, LockItem> toLockItemsByKey(final List<LockItem> allLocksFromDynamoDB) {
+    final Map<String, LockItem> locksByKey = new HashMap<>();
+    for (final LockItem lockItem : allLocksFromDynamoDB) {
+      locksByKey.put(getLockKey(lockItem), lockItem);
+    }
+
+    return locksByKey;
+  }
+
+  private static String getLockKey(LockItem lockItem) {
+    return lockItem.getPartitionKey() + lockItem.getSortKey().orElse("");
+  }
+
+}

--- a/src/test/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedQueryIteratorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedQueryIteratorTest.java
@@ -1,0 +1,50 @@
+package com.amazonaws.services.dynamodbv2;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
+import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LockItemPaginatedQueryIteratorTest extends TestCase {
+  @Mock
+  DynamoDbClient dynamodb;
+  @Mock
+  LockItemFactory factory;
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void remove_throwsUnsupportedOperationException() {
+    LockItemPaginatedQueryIterator
+        sut = new LockItemPaginatedQueryIterator(dynamodb, QueryRequest.builder().build(), factory);
+    sut.remove();
+  }
+
+  @Test(expected = NoSuchElementException.class)
+  public void next_whenDoesNotHaveNext_throwsNoSuchElementException() {
+    QueryRequest request = QueryRequest.builder().build();
+    LockItemPaginatedQueryIterator
+        sut = new LockItemPaginatedQueryIterator(dynamodb, request, factory);
+    List<Map<String, AttributeValue>> list1 = new ArrayList<>();
+    list1.add(new HashMap<>());
+    when(dynamodb.query(ArgumentMatchers.<QueryRequest>any()))
+        .thenReturn(
+            QueryResponse.builder().items(list1).count(1).lastEvaluatedKey(new HashMap<>()).build())
+        .thenReturn(QueryResponse.builder().items(Collections.emptyList()).count(0).build());
+    sut.next();
+    sut.next();
+  }
+}

--- a/src/test/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedQueryIteratorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedQueryIteratorTest.java
@@ -1,7 +1,20 @@
+/**
+ * Copyright 2013-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * <p>
+ * Licensed under the Amazon Software License (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ * <p>
+ * http://aws.amazon.com/asl/
+ * <p>
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express
+ * or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
 package com.amazonaws.services.dynamodbv2;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,8 +30,15 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.QueryResponse;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+/**
+ * Unit tests for {@link LockItemPaginatedQueryIterator} that test for
+ * {@link LockItemPaginatedQueryIterator#next()}, {@link LockItemPaginatedQueryIterator#hasNext()}
+ * and {@link LockItemPaginatedQueryIterator#remove()}
+ */
 @RunWith(MockitoJUnitRunner.class)
 public class LockItemPaginatedQueryIteratorTest extends TestCase {
   @Mock
@@ -38,13 +58,150 @@ public class LockItemPaginatedQueryIteratorTest extends TestCase {
     QueryRequest request = QueryRequest.builder().build();
     LockItemPaginatedQueryIterator
         sut = new LockItemPaginatedQueryIterator(dynamodb, request, factory);
-    List<Map<String, AttributeValue>> list1 = new ArrayList<>();
-    list1.add(new HashMap<>());
+    List<Map<String, AttributeValue>> items = new ArrayList<>();
+    items.add(new HashMap<>());
     when(dynamodb.query(ArgumentMatchers.<QueryRequest>any()))
         .thenReturn(
-            QueryResponse.builder().items(list1).count(1).lastEvaluatedKey(new HashMap<>()).build())
-        .thenReturn(QueryResponse.builder().items(Collections.emptyList()).count(0).build());
+            QueryResponse.builder().items(items).count(1).lastEvaluatedKey(new HashMap<>()).build())
+        .thenReturn(QueryResponse.builder().items(items).count(1).build());
     sut.next();
     sut.next();
   }
+
+  @Test
+  public void next_whenMultiplePages_shouldReturnAll() {
+    QueryRequest request = QueryRequest.builder().build();
+    LockItemPaginatedQueryIterator
+        sut = new LockItemPaginatedQueryIterator(dynamodb, request, factory);
+
+    assertFalse(sut.hasLoadedFirstPage());
+
+    List<Map<String, AttributeValue>> page1 = new ArrayList<>();
+    HashMap<String, AttributeValue> lockItem1 = new HashMap<>();
+    page1.add(lockItem1);
+
+    List<Map<String, AttributeValue>> page2 = new ArrayList<>();
+    HashMap<String, AttributeValue> lockItem2 = new HashMap<>();
+    page2.add(lockItem2);
+
+    HashMap<String, AttributeValue> lastEvaluatedKey = new HashMap<>();
+    lastEvaluatedKey.put("has_next", null);
+    LockItem mock1 = mock(LockItem.class);
+    when(mock1.getOwnerName()).thenReturn("1");
+    LockItem mock2 = mock(LockItem.class);
+    when(mock2.getOwnerName()).thenReturn("2");
+
+    // Single item pages only to simulate multiple pages.
+    when(factory.create(any())).thenReturn(mock1).thenReturn(mock2);
+    when(dynamodb.query(ArgumentMatchers.<QueryRequest>any()))
+        .thenReturn(
+            QueryResponse.builder().items(page1).count(1).lastEvaluatedKey(lastEvaluatedKey).build())
+        .thenReturn(QueryResponse.builder().items(page2).count(1).build());
+
+    LockItem item1 = sut.next();
+    assertEquals(item1.getOwnerName(), "1");
+    LockItem item2 = sut.next();
+    assertEquals(item2.getOwnerName(), "2");
+  }
+
+  @Test
+  public void next_whenMultipleItemsInOnePage_shouldReturnAll() {
+    QueryRequest request = QueryRequest.builder().build();
+    LockItemPaginatedQueryIterator
+        sut = new LockItemPaginatedQueryIterator(dynamodb, request, factory);
+
+    assertFalse(sut.hasLoadedFirstPage());
+
+    List<Map<String, AttributeValue>> page1 = new ArrayList<>();
+    HashMap<String, AttributeValue> lockItem1 = new HashMap<>();
+    HashMap<String, AttributeValue> lockItem2 = new HashMap<>();
+    page1.add(lockItem1);
+    page1.add(lockItem2);
+
+    LockItem mock1 = mock(LockItem.class);
+    when(mock1.getOwnerName()).thenReturn("1");
+    LockItem mock2 = mock(LockItem.class);
+    when(mock2.getOwnerName()).thenReturn("2");
+
+    // Multiple items in one page.
+    when(factory.create(any())).thenReturn(mock1).thenReturn(mock2);
+    when(dynamodb.query(ArgumentMatchers.<QueryRequest>any()))
+        .thenReturn(
+            QueryResponse.builder().items(page1).count(2).build());
+
+    LockItem item1 = sut.next();
+    assertEquals(item1.getOwnerName(), "1");
+    LockItem item2 = sut.next();
+    assertEquals(item2.getOwnerName(), "2");
+  }
+
+  @Test
+  public void hasNext_whenMultiplePages_shouldReturnTrueBeforeLastOne() {
+    QueryRequest request = QueryRequest.builder().build();
+    LockItemPaginatedQueryIterator
+        sut = new LockItemPaginatedQueryIterator(dynamodb, request, factory);
+
+    assertFalse(sut.hasLoadedFirstPage());
+
+    List<Map<String, AttributeValue>> page1 = new ArrayList<>();
+    HashMap<String, AttributeValue> lockItem1 = new HashMap<>();
+    page1.add(lockItem1);
+
+    List<Map<String, AttributeValue>> page2 = new ArrayList<>();
+    HashMap<String, AttributeValue> lockItem2 = new HashMap<>();
+    page2.add(lockItem2);
+
+    HashMap<String, AttributeValue> lastEvaluatedKey = new HashMap<>();
+    lastEvaluatedKey.put("has_next", null);
+    LockItem mock1 = mock(LockItem.class);
+    when(mock1.getOwnerName()).thenReturn("1");
+    LockItem mock2 = mock(LockItem.class);
+    when(mock2.getOwnerName()).thenReturn("2");
+
+    // Single item pages only to simulate multiple pages.
+    when(factory.create(any())).thenReturn(mock1).thenReturn(mock2);
+    when(dynamodb.query(ArgumentMatchers.<QueryRequest>any()))
+        .thenReturn(
+            QueryResponse.builder().items(page1).count(1).lastEvaluatedKey(lastEvaluatedKey).build())
+        .thenReturn(QueryResponse.builder().items(page2).count(1).build());
+
+    assertTrue(sut.hasNext());
+    sut.next();
+    assertTrue(sut.hasNext());
+    sut.next();
+    assertFalse(sut.hasNext());
+  }
+
+  @Test
+  public void hasNext_whenMultipleItemsInOnePage_shouldReturnTrueBeforeLastOne() {
+    QueryRequest request = QueryRequest.builder().build();
+    LockItemPaginatedQueryIterator
+        sut = new LockItemPaginatedQueryIterator(dynamodb, request, factory);
+
+    assertFalse(sut.hasLoadedFirstPage());
+
+    List<Map<String, AttributeValue>> page1 = new ArrayList<>();
+    HashMap<String, AttributeValue> lockItem1 = new HashMap<>();
+    HashMap<String, AttributeValue> lockItem2 = new HashMap<>();
+    page1.add(lockItem1);
+    page1.add(lockItem2);
+
+    LockItem mock1 = mock(LockItem.class);
+    when(mock1.getOwnerName()).thenReturn("1");
+    LockItem mock2 = mock(LockItem.class);
+    when(mock2.getOwnerName()).thenReturn("2");
+
+    // Multiple items in one page.
+    when(factory.create(any())).thenReturn(mock1).thenReturn(mock2);
+    when(dynamodb.query(ArgumentMatchers.<QueryRequest>any()))
+        .thenReturn(
+            QueryResponse.builder().items(page1).count(2).build());
+
+    assertTrue(sut.hasNext());
+    sut.next();
+    assertTrue(sut.hasNext());
+    sut.next();
+    assertFalse(sut.hasNext());
+  }
+
 }

--- a/src/test/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedQueryIteratorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/LockItemPaginatedQueryIteratorTest.java
@@ -154,9 +154,7 @@ public class LockItemPaginatedQueryIteratorTest extends TestCase {
     HashMap<String, AttributeValue> lastEvaluatedKey = new HashMap<>();
     lastEvaluatedKey.put("has_next", null);
     LockItem mock1 = mock(LockItem.class);
-    when(mock1.getOwnerName()).thenReturn("1");
     LockItem mock2 = mock(LockItem.class);
-    when(mock2.getOwnerName()).thenReturn("2");
 
     // Single item pages only to simulate multiple pages.
     when(factory.create(any())).thenReturn(mock1).thenReturn(mock2);
@@ -187,9 +185,7 @@ public class LockItemPaginatedQueryIteratorTest extends TestCase {
     page1.add(lockItem2);
 
     LockItem mock1 = mock(LockItem.class);
-    when(mock1.getOwnerName()).thenReturn("1");
     LockItem mock2 = mock(LockItem.class);
-    when(mock2.getOwnerName()).thenReturn("2");
 
     // Multiple items in one page.
     when(factory.create(any())).thenReturn(mock1).thenReturn(mock2);


### PR DESCRIPTION
*Issue #, if available:* 58

*Description of changes:*

Add the following method to the AmazonDynamoDBLockClient:

```
public Stream<LockItem> getLocksByPartitionKey(String key, final boolean deleteOnRelease)
```

This method queries LockItems having the same partition key (but different sort key). It does this by calling `dynamoDB.query(this.queryRequest)`.

Currently, the only way to read multiple Lock Items from the database is by performing a scan. 
This change allows the client to query for a subset of the leases only based on the partition key.