### PR TITLE
Fix: Lock can be acquired after lease duration if the current owner has been terminated unexpectedly when using skipBlockingWait=true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 target/*
 .project
 .classpath
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
         <jdk.version>1.8</jdk.version>
 
         <!-- build toolchain -->
-        <maven.assembly.plugin.version>3.1.1</maven.assembly.plugin.version>
-        <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
+        <maven.assembly.plugin.version>3.3.0</maven.assembly.plugin.version>
+        <maven.compiler.plugin.version>3.9.0</maven.compiler.plugin.version>
         <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
         <maven.enforcer.plugin.version>3.0.0-M2</maven.enforcer.plugin.version>
         <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
@@ -31,23 +31,23 @@
         <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
 
         <!-- compile dependencies -->
-        <aws.java.sdk.version>2.3.5</aws.java.sdk.version>
-        <netty.version>[4.1.59.Final,)</netty.version>
+        <aws.java.sdk.version>2.17.198</aws.java.sdk.version>
+        <netty.version>[4.1.77.Final,)</netty.version>
         <commons-logging.version>1.2</commons-logging.version>
 
         <!-- test dependencies -->
-        <dynamodblocal.version>1.11.119</dynamodblocal.version>
+        <dynamodblocal.version>1.15.0</dynamodblocal.version>
         <mockito.version>2.23.0</mockito.version>
         <powermock.version>2.0.0</powermock.version>
         <hamcrest.version>1.3</hamcrest.version>
         <bytebuddy.version>1.9.3</bytebuddy.version>
 
         <!-- test toolchain -->
-        <junit.version>4.13.1</junit.version>
-        <log4j-core.version>2.17.1</log4j-core.version>
-        <maven.surefire.version>3.0.0-M3</maven.surefire.version>
-        <maven.failsafe.version>3.0.0-M3</maven.failsafe.version>
-        <docker.maven.plugin.version>0.28.0</docker.maven.plugin.version>
+        <junit.version>4.13.2</junit.version>
+        <log4j-core.version>2.17.2</log4j-core.version>
+        <maven.surefire.version>3.0.0-M5</maven.surefire.version>
+        <maven.failsafe.version>3.0.0-M5</maven.failsafe.version>
+        <docker.maven.plugin.version>0.38.1</docker.maven.plugin.version>
         <build.profile.id>dev</build.profile.id>
         <integration-test.category>*/BasicLockClientTests.java,*/GetAllLocksTests.java,*/GetLocksByPartitionKeyTest.java,*/ConsistentLockDataStressTest.java</integration-test.category>
 
@@ -60,6 +60,10 @@
         <jacoco-aggregate-destFile>${project.build.directory}/coverage-reports/aggregate.exec</jacoco-aggregate-destFile>
     </properties>
     <developers>
+        <developer>
+            <name>Chris Ryan</name>
+            <email>chrisryan@squareup.com</email>
+        </developer>
         <developer>
             <name>Justin Lin</name>
             <email>lnjus@amazon.com</email>

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
@@ -814,7 +814,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
     public Optional<LockItem> tryAcquireLock(final AcquireLockOptions options) throws InterruptedException {
         try {
             return Optional.of(this.acquireLock(options));
-        } catch (final LockNotGrantedException x) {
+        } catch (final LockNotGrantedException | LockCurrentlyUnavailableException x) {
             return Optional.empty();
         }
     }

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
@@ -627,7 +627,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
     }
 
     private LockItem upsertAndMonitorReleasedLock(
-        AcquireLockOptions options, 
+        AcquireLockOptions options,
         String key,
         Optional<String> sortKey,
         boolean deleteLockOnRelease,

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
@@ -626,9 +626,17 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
         }
     }
 
-    private LockItem upsertAndMonitorReleasedLock(AcquireLockOptions options, String key, Optional<String> sortKey, boolean
-                                                                                                                        deleteLockOnRelease, Optional<SessionMonitor> sessionMonitor, Optional<LockItem> existingLock, Optional<ByteBuffer>
-                                                                                                                                                                                                                           newLockData, Map<String, AttributeValue> item, String recordVersionNumber) {
+    private LockItem upsertAndMonitorReleasedLock(
+        AcquireLockOptions options, 
+        String key,
+        Optional<String> sortKey,
+        boolean deleteLockOnRelease,
+        Optional<SessionMonitor> sessionMonitor,
+        Optional<LockItem> existingLock,
+        Optional<ByteBuffer> newLockData,
+        Map<String, AttributeValue> item,
+        String recordVersionNumber
+    ) {
 
         final String conditionalExpression;
         final boolean updateExistingLockRecord = options.getUpdateExistingLockRecord();
@@ -712,9 +720,16 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
      * @param recordVersionNumber the rvn to condition the PutItem call on.
      * @return a new monitored LockItem
      */
-    private LockItem upsertAndMonitorNewLock(AcquireLockOptions options, String key, Optional<String> sortKey,
-                                             boolean deleteLockOnRelease, Optional<SessionMonitor> sessionMonitor,
-                                             Optional<ByteBuffer> newLockData, Map<String, AttributeValue> item, String recordVersionNumber) {
+    private LockItem upsertAndMonitorNewLock(
+        AcquireLockOptions options,
+        String key,
+        Optional<String> sortKey,
+        boolean deleteLockOnRelease,
+        Optional<SessionMonitor> sessionMonitor,
+        Optional<ByteBuffer> newLockData,
+        Map<String, AttributeValue> item,
+        String recordVersionNumber
+    ) {
 
         final Map<String, String> expressionAttributeNames = new HashMap<>();
         expressionAttributeNames.put(PK_PATH_EXPRESSION_VARIABLE, this.partitionKeyName);

--- a/src/main/java/com/amazonaws/services/dynamodbv2/util/LockClientUtils.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/util/LockClientUtils.java
@@ -24,12 +24,11 @@ package com.amazonaws.services.dynamodbv2.util;
 public enum LockClientUtils {
     INSTANCE;
     /**
-     * Calls System.nanoTime() and converts it to milliseconds. This is used by the lock client, since the lock client
-     * uses milliseconds as its base unit instead of nanoseconds.
+     * Calls System.currentTimeMillis().
      *
-     * @return the current time in milliseconds, but not since epoch. It is only useful for elapsed time, not absolute time.
+     * @return the current time in milliseconds.
      */
     public long millisecondTime() {
-        return System.nanoTime() / 1000000;
+        return System.currentTimeMillis();
     }
 }

--- a/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
@@ -110,6 +110,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("ownerName", AttributeValue.builder().s("foobar").build());
         item.put("recordVersionNumber", AttributeValue.builder().s("oolala").build());
         item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        item.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
         when(dynamodb.getItem(ArgumentMatchers.<GetItemRequest>any())).thenReturn(GetItemResponse.builder().item(item).build());
         LockItem lockItem = lockClient.acquireLock(AcquireLockOptions.builder(PARTITION_KEY)
                 .withSessionMonitor(3001,
@@ -162,6 +163,7 @@ public class AmazonDynamoDBLockClientTest {
         Map<String, AttributeValue> lockItem = new HashMap<>(3);
         lockItem.put("ownerName", AttributeValue.builder().s("owner").build());
         lockItem.put("leaseDuration", AttributeValue.builder().s("1").build());
+        lockItem.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
         lockItem.put("recordVersionNumber", AttributeValue.builder().s("uuid").build());
         when(dynamodb.getItem(ArgumentMatchers.<GetItemRequest>any())).thenReturn(GetItemResponse.builder().item(lockItem).build());
         when(dynamodb.putItem(ArgumentMatchers.<PutItemRequest>any())).thenThrow(ConditionalCheckFailedException.builder().message("item existed").build());
@@ -178,6 +180,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("ownerName", AttributeValue.builder().s("foobar").build());
         item.put("recordVersionNumber", AttributeValue.builder().s("oolala").build());
         item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        item.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
         when(dynamodb.getItem(Mockito.<GetItemRequest>any())).thenReturn(GetItemResponse.builder().item(item).build());
         when(dynamodb.putItem(Mockito.<PutItemRequest>any())).thenThrow(ProvisionedThroughputExceededException.builder()
                 .message("Provisioned Throughput for the table exceeded").build());
@@ -212,6 +215,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("ownerName", AttributeValue.builder().s("foobar").build());
         item.put("recordVersionNumber", AttributeValue.builder().s(uuid.toString()).build());
         item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        item.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
         item.put("isReleased", AttributeValue.builder().bool(true).build());
 
         doAnswer((InvocationOnMock invocation) -> GetItemResponse.builder().item(item).build())
@@ -229,6 +233,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("ownerName", AttributeValue.builder().s("foobar").build());
         item.put("recordVersionNumber", AttributeValue.builder().s(uuid.toString()).build());
         item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        item.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
         item.put("isReleased", AttributeValue.builder().bool(true).build());
         when(dynamodb.getItem(Mockito.<GetItemRequest>any())).thenReturn(GetItemResponse.builder().item(item).build());
         LockItem lockItem = client.acquireLock(AcquireLockOptions.builder("asdf").withAcquireOnlyIfLockAlreadyExists(true).build());
@@ -245,6 +250,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("ownerName", AttributeValue.builder().s("foobar").build());
         item.put("recordVersionNumber", AttributeValue.builder().s(uuid.toString()).build());
         item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        item.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
         Map<String, AttributeValue> differentRvn1 = new HashMap<>(item);
         differentRvn1.put("recordVersionNumber",
             AttributeValue.builder().s("uuid1").build());
@@ -311,6 +317,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("ownerName", AttributeValue.builder().s("foobar").build());
         item.put("recordVersionNumber", AttributeValue.builder().s(uuid.toString()).build());
         item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        item.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
 
         Map<String, AttributeValue> differentItem = new HashMap<>(item);
         differentItem.put("recordVersionNumber", AttributeValue.builder().s("a different uuid").build());
@@ -336,6 +343,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("ownerName", AttributeValue.builder().s("foobar").build());
         item.put("recordVersionNumber", AttributeValue.builder().s(uuid.toString()).build());
         item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        item.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
         item.put("isReleased", AttributeValue.builder().bool(true).build());
         doAnswer((InvocationOnMock invocation) -> GetItemResponse.builder().item(item).build())
                 .when(dynamodb).getItem(Mockito.<GetItemRequest>any());
@@ -351,6 +359,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("ownerName", AttributeValue.builder().s("foobar").build());
         item.put("recordVersionNumber", AttributeValue.builder().s("a specific rvn").build());
         item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        item.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
         item.put("isReleased", AttributeValue.builder().bool(true).build());
         when(dynamodb.getItem(Mockito.<GetItemRequest>any())).thenReturn(GetItemResponse.builder().item(item).build());
         LockItem lockItem = client.acquireLock(AcquireLockOptions.builder("asdf").withAcquireReleasedLocksConsistently(true).withUpdateExistingLockRecord
@@ -372,6 +381,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("ownerName", AttributeValue.builder().s("foobar").build());
         item.put("recordVersionNumber", AttributeValue.builder().s("a specific rvn").build());
         item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        item.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
         item.put("isReleased", AttributeValue.builder().bool(true).build());
         when(dynamodb.getItem(Mockito.<GetItemRequest>any())).thenReturn(GetItemResponse.builder().item(item).build());
         LockItem lockItem = client.acquireLock(AcquireLockOptions.builder("asdf").withAcquireReleasedLocksConsistently(true).withUpdateExistingLockRecord
@@ -416,6 +426,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("ownerName", AttributeValue.builder().s("foobar").build());
         item.put("recordVersionNumber", AttributeValue.builder().s(uuid.toString()).build());
         item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        item.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
         item.put("isReleased", AttributeValue.builder().bool(true).build());
         when(dynamodb.getItem(Mockito.<GetItemRequest>any()))
             .thenReturn(GetItemResponse.builder().item(item).build())
@@ -439,6 +450,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("ownerName", AttributeValue.builder().s("foobar").build());
         item.put("recordVersionNumber", AttributeValue.builder().s(uuid.toString()).build());
         item.put("leaseDuration", AttributeValue.builder().s("100000").build());
+        item.put("lookupTime", AttributeValue.builder().s("" +  LockClientUtils.INSTANCE.millisecondTime()).build());
         when(dynamodb.getItem(Mockito.<GetItemRequest>any()))
             .thenReturn(GetItemResponse.builder().item(item).build())
             .thenReturn(GetItemResponse.builder().build());


### PR DESCRIPTION
*Issue #, if available:* [44](https://github.com/awslabs/amazon-dynamodb-lock-client/issues/44)

*Description of changes:*

This solves the problem with the issue raised, allowing skipBlockingWait flag to be used safely.  It tracks the "lookupTime" for the lock to handle if another client that has the lock has been terminated unexpectedly - and therefore can't update the lock itself.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
