### PR TITLE
Removing Warning / Clarification from README.md since new version(1.2…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,6 @@ questions.
 
 [![Build Status](https://travis-ci.org/awslabs/dynamodb-lock-client.svg?branch=master)](https://travis-ci.org/awslabs/dynamodb-lock-client)
 
-# Warning / Clarification: 
-Only v1.1.0 has been released to Maven. We recommend if you are are consuming from Maven to refer to the [1.1.x branch we have](https://github.com/awslabs/amazon-dynamodb-lock-client/tree/v1.1.x). v1.2.x is not yet released, containing SDKV2 changes, and so-on. 
-
 ## Use cases
 A common use case for this lock client is:
 let's say you have a distributed system that needs to periodically do work on a given campaign


### PR DESCRIPTION

*Description of changes:*

Removing Warning / Clarification from README.md since new version(1.2.0) of DynamoDBLock Client available on Maven now

https://repo1.maven.org/maven2/com/amazonaws/dynamodb-lock-client/1.2.0/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
