### PR TITLE
Add a withClockSkewUpperBound option when acquiring a lock

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/AcquireLockOptions.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AcquireLockOptions.java
@@ -45,6 +45,7 @@ public class AcquireLockOptions {
     private final Boolean acquireReleasedLocksConsistently;
     private final Optional<SessionMonitor> sessionMonitor;
     private final Boolean reentrant;
+    private final Optional<Long> clockSkewUpperBound;
 
     /**
      * Setting this flag to true will prevent the thread from being blocked (put to sleep) for the lease duration and
@@ -72,6 +73,7 @@ public class AcquireLockOptions {
         private Boolean updateExistingLockRecord;
         private Boolean acquireReleasedLocksConsistently;
         private Boolean reentrant;
+        private Optional<Long> clockSkewUpperBound;
 
         private long safeTimeWithoutHeartbeat;
         private Optional<Runnable> sessionMonitorCallback;
@@ -90,6 +92,7 @@ public class AcquireLockOptions {
             this.shouldSkipBlockingWait = false;
             this.acquireReleasedLocksConsistently = false;
             this.reentrant = false;
+            this.clockSkewUpperBound = Optional.empty();;
         }
 
         /**
@@ -257,6 +260,22 @@ public class AcquireLockOptions {
         }
 
         /**
+         * In combination with withShouldSkipBlockingWait(true) this allows a node to rely on a lastTouchedAt value on the DynamoDb
+         * entry to take over locks which have expired but have not been deleted or marked as released within DynamoDb (which can occur
+         * due to an ungraceful shutdown of the owning node).
+         *
+         * It's critically important that this error bound is accurate to the nodes that are relying on the lock client. If not,
+         * correctness problems can occur.
+         *
+         * @param clockSkewUpperBound the upper error bound of clock skew across the nodes running this client
+         * @return a reference to this builder for fluent method chaining
+         */
+        public AcquireLockOptionsBuilder withClockSkewUpperBound(final Long clockSkewUpperBound) {
+            this.clockSkewUpperBound = Optional.ofNullable(clockSkewUpperBound);
+            return this;
+        }
+
+        /**
          * <p>
          * Registers a "SessionMonitor."
          * </p>
@@ -333,7 +352,7 @@ public class AcquireLockOptions {
             }
             return new AcquireLockOptions(this.partitionKey, this.sortKey, this.data, this.replaceData, this.deleteLockOnRelease, this.acquireOnlyIfLockAlreadyExists,
                     this.refreshPeriod, this.additionalTimeToWaitForLock, this.timeUnit, this.additionalAttributes, sessionMonitor,
-                    this.updateExistingLockRecord, this.shouldSkipBlockingWait, this.acquireReleasedLocksConsistently, this.reentrant);
+                    this.updateExistingLockRecord, this.shouldSkipBlockingWait, this.acquireReleasedLocksConsistently, this.reentrant, this.clockSkewUpperBound);
         }
 
         @Override
@@ -342,7 +361,8 @@ public class AcquireLockOptions {
                 + this.replaceData + ", deleteLockOnRelease=" + this.deleteLockOnRelease + ", refreshPeriod=" + this.refreshPeriod + ", additionalTimeToWaitForLock="
                 + this.additionalTimeToWaitForLock + ", timeUnit=" + this.timeUnit + ", additionalAttributes=" + this.additionalAttributes + ", safeTimeWithoutHeartbeat="
                 + this.safeTimeWithoutHeartbeat + ", sessionMonitorCallback=" + this.sessionMonitorCallback + ", acquireReleasedLocksConsistently="
-                + this.acquireReleasedLocksConsistently + ", reentrant=" + this.reentrant+ ")";
+                + this.acquireReleasedLocksConsistently + ", reentrant=" + this.reentrant+ ", this.clockSkewUpperBound=" + this.clockSkewUpperBound
+              + ")";
         }
     }
 
@@ -360,7 +380,8 @@ public class AcquireLockOptions {
     private AcquireLockOptions(final String partitionKey, final Optional<String> sortKey, final Optional<ByteBuffer> data, final Boolean replaceData,
        final Boolean deleteLockOnRelease, final Boolean acquireOnlyIfLockAlreadyExists, final Long refreshPeriod, final Long additionalTimeToWaitForLock,
        final TimeUnit timeUnit, final Map<String, AttributeValue> additionalAttributes, final Optional<SessionMonitor> sessionMonitor,
-       final Boolean updateExistingLockRecord, final Boolean shouldSkipBlockingWait, final Boolean acquireReleasedLocksConsistently, Boolean reentrant) {
+       final Boolean updateExistingLockRecord, final Boolean shouldSkipBlockingWait, final Boolean acquireReleasedLocksConsistently, Boolean reentrant,
+       final Optional<Long> clockSkewUpperBound) {
        this.partitionKey = partitionKey;
        this.sortKey = sortKey;
        this.data = data;
@@ -376,6 +397,7 @@ public class AcquireLockOptions {
        this.shouldSkipBlockingWait = shouldSkipBlockingWait;
        this.acquireReleasedLocksConsistently = acquireReleasedLocksConsistently;
        this.reentrant = reentrant;
+       this.clockSkewUpperBound = clockSkewUpperBound;
     }
 
     String getPartitionKey() {
@@ -424,6 +446,8 @@ public class AcquireLockOptions {
       return this.reentrant;
     }
 
+    Optional<Long> getClockSkewUpperBound() { return this.clockSkewUpperBound; }
+
     Map<String, AttributeValue> getAdditionalAttributes() {
         return this.additionalAttributes;
     }
@@ -460,7 +484,8 @@ public class AcquireLockOptions {
                 && Objects.equals(this.updateExistingLockRecord, otherOptions.updateExistingLockRecord)
                 && Objects.equals(this.shouldSkipBlockingWait, otherOptions.shouldSkipBlockingWait)
                 && Objects.equals(this.acquireReleasedLocksConsistently, otherOptions.acquireReleasedLocksConsistently)
-                && Objects.equals(this.reentrant, otherOptions.reentrant);
+                && Objects.equals(this.reentrant, otherOptions.reentrant)
+                && Objects.equals(this.clockSkewUpperBound, otherOptions.clockSkewUpperBound);
     }
 
     @Override
@@ -468,7 +493,7 @@ public class AcquireLockOptions {
         return Objects.hash(this.partitionKey, this.sortKey, this.data, this.replaceData, this.deleteLockOnRelease,
                 this.acquireOnlyIfLockAlreadyExists, this.refreshPeriod, this.additionalTimeToWaitForLock, this.timeUnit,
                 this.additionalAttributes, this.sessionMonitor, this.updateExistingLockRecord,
-                this.shouldSkipBlockingWait, this.acquireReleasedLocksConsistently, this.reentrant);
+                this.shouldSkipBlockingWait, this.acquireReleasedLocksConsistently, this.reentrant, this.clockSkewUpperBound);
 
     }
 

--- a/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
@@ -46,6 +46,7 @@ public class LockItem implements Closeable {
     private final StringBuffer recordVersionNumber;
     private final AtomicLong leaseDuration;
     private final Map<String, AttributeValue> additionalAttributes;
+    private final Optional<AtomicLong> lastTouchedAt;
 
     private final Optional<SessionMonitor> sessionMonitor;
 
@@ -63,7 +64,8 @@ public class LockItem implements Closeable {
      * @param deleteLockItemOnClose         Whether or not to delete the lock item when releasing it
      * @param ownerName                     The owner associated with the lock
      * @param leaseDuration                 How long the lease for the lock is (in milliseconds)
-     * @param lastUpdatedTimeInMilliseconds How recently the lock was updated (in milliseconds)
+     * @param lookupTime                    How recently the lock was updated (in milliseconds). Not the
+     *                                      wall clock time. This is backed by nanoTime().
      * @param recordVersionNumber           The current record version number of the lock -- this is
      *                                      globally unique and changes each time the lock is updated
      * @param isReleased                    Whether the item in DynamoDB is marked as released, but still
@@ -72,14 +74,18 @@ public class LockItem implements Closeable {
      *                                      the lock
      * @param additionalAttributes          Additional attributes that can optionally be stored alongside
      *                                      the lock
+     * @param lastTouchedAt                 The wall clock time (in milliseconds since epoch) that this lease
+     *                                      was last touched at via heartbeat or acquire. Used when
+     *                                      clockSkewUpperBound is set.
      */
     LockItem(final AmazonDynamoDBLockClient client, final String partitionKey, final Optional<String> sortKey, final Optional<ByteBuffer> data, final boolean deleteLockItemOnClose,
-        final String ownerName, final long leaseDuration, final long lastUpdatedTimeInMilliseconds, final String recordVersionNumber, final boolean isReleased,
-        final Optional<SessionMonitor> sessionMonitor, final Map<String, AttributeValue> additionalAttributes) {
+        final String ownerName, final long leaseDuration, final long lookupTime, final String recordVersionNumber, final boolean isReleased,
+        final Optional<SessionMonitor> sessionMonitor, final Map<String, AttributeValue> additionalAttributes, final Optional<AtomicLong> lastTouchedAt) {
         Objects.requireNonNull(partitionKey, "Cannot create a lock with a null key");
         Objects.requireNonNull(ownerName, "Cannot create a lock with a null owner");
         Objects.requireNonNull(sortKey, "Cannot create a lock with a null sortKey (use Optional.empty())");
         Objects.requireNonNull(data, "Cannot create a lock with a null data (use Optional.empty())");
+        Objects.requireNonNull(lastTouchedAt, "Cannot create a lock with a null lastTouchedAt (use Optional.empty())");
         this.client = client;
         this.partitionKey = partitionKey;
         this.sortKey = sortKey;
@@ -88,11 +94,12 @@ public class LockItem implements Closeable {
         this.deleteLockItemOnClose = deleteLockItemOnClose;
 
         this.leaseDuration = new AtomicLong(leaseDuration);
-        this.lookupTime = new AtomicLong(lastUpdatedTimeInMilliseconds);
+        this.lookupTime = new AtomicLong(lookupTime);
         this.recordVersionNumber = new StringBuffer(recordVersionNumber);
         this.isReleased = isReleased;
         this.sessionMonitor = sessionMonitor;
         this.additionalAttributes = additionalAttributes;
+        this.lastTouchedAt = lastTouchedAt;
     }
 
     /**
@@ -130,6 +137,14 @@ public class LockItem implements Closeable {
         return this.additionalAttributes;
     }
 
+    /**
+     * Returns the last touched at time since heartbeat or initial lock acquisition.
+     *
+     * @return The last touched at milliseconds since epoch
+     */
+    public Optional<AtomicLong> getLastTouchedAt() {
+        return this.lastTouchedAt;
+    }
 
     /**
      * Returns the name of the owner that owns this lock.
@@ -197,9 +212,9 @@ public class LockItem implements Closeable {
             .orElse("");
         return String
             .format("LockItem{Partition Key=%s, Sort Key=%s, Owner Name=%s, Lookup Time=%d, Lease Duration=%d, "
-                    + "Record Version Number=%s, Delete On Close=%s, Data=%s, Is Released=%s}",
+                    + "Record Version Number=%s, Delete On Close=%s, Data=%s, Is Released=%s, Last touched at=%s}",
                 this.partitionKey, this.sortKey, this.ownerName, this.lookupTime.get(), this.leaseDuration.get(), this.recordVersionNumber, this.deleteLockItemOnClose,
-                dataString, this.isReleased);
+                dataString, this.isReleased, this.lastTouchedAt);
     }
 
     /**
@@ -296,6 +311,10 @@ public class LockItem implements Closeable {
         this.recordVersionNumber.replace(0, recordVersionNumber.length(), recordVersionNumber);
         this.lookupTime.set(lastUpdateOfLock);
         this.leaseDuration.set(leaseDurationToEnsureInMilliseconds);
+    }
+
+    void updateLastTouchedAt(long lastTouchedAt) {
+        this.lastTouchedAt.ifPresent(value -> value.set(lastTouchedAt));
     }
 
     /*

--- a/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
@@ -454,7 +454,7 @@ public class AmazonDynamoDBLockClientTest {
         AmazonDynamoDBLockClient client = getLockClient();
         LockItem item = new LockItem(client, "a", Optional.empty(), Optional.of(ByteBuffer.wrap("data".getBytes())),
             false, uuid.toString(), 1L, 2L, "rvn", false,
-            Optional.empty(), null);
+            Optional.empty(), null, Optional.empty());
         client.sendHeartbeat(SendHeartbeatOptions.builder(item).withDeleteData(true).withData(ByteBuffer.wrap("data".getBytes())).build());
     }
 
@@ -465,7 +465,7 @@ public class AmazonDynamoDBLockClientTest {
         long lastUpdatedTimeInMilliseconds = 2l;
         LockItem item = new LockItem(client, "a", Optional.empty(), Optional.of(ByteBuffer.wrap("data".getBytes())),
             false, uuid.toString(), 1L, lastUpdatedTimeInMilliseconds,
-            "rvn", false, Optional.empty(), null);
+            "rvn", false, Optional.empty(), null, Optional.empty());
         client.sendHeartbeat(SendHeartbeatOptions.builder(item).withDeleteData(null).withData(ByteBuffer.wrap("data".getBytes())).build());
     }
 
@@ -476,7 +476,7 @@ public class AmazonDynamoDBLockClientTest {
         long lastUpdatedTimeInMilliseconds = Long.MAX_VALUE;
         LockItem item = new LockItem(client, "a", Optional.empty(), Optional.of(ByteBuffer.wrap("data".getBytes())),
             false, "different owner", 1L, lastUpdatedTimeInMilliseconds,
-            "rvn", false, Optional.empty(), null);
+            "rvn", false, Optional.empty(), null, Optional.empty());
         client.sendHeartbeat(SendHeartbeatOptions.builder(item).withDeleteData(null).withData(ByteBuffer.wrap("data".getBytes())).build());
     }
 
@@ -487,7 +487,7 @@ public class AmazonDynamoDBLockClientTest {
         long lastUpdatedTimeInMilliseconds = Long.MAX_VALUE;
         LockItem item = new LockItem(client, "a", Optional.empty(), Optional.of(ByteBuffer.wrap("data".getBytes())),
             false, uuid.toString(), 1L, lastUpdatedTimeInMilliseconds,
-            "rvn", true, Optional.empty(), null);
+            "rvn", true, Optional.empty(), null, Optional.empty());
         client.sendHeartbeat(SendHeartbeatOptions.builder(item).withDeleteData(null).withData(ByteBuffer.wrap("data".getBytes())).build());
     }
 
@@ -498,7 +498,7 @@ public class AmazonDynamoDBLockClientTest {
         long lastUpdatedTimeInMilliseconds = Long.MAX_VALUE;
         LockItem item = new LockItem(client, "a", Optional.empty(), Optional.of(ByteBuffer.wrap("data".getBytes())),
             false, uuid.toString(), 1L, lastUpdatedTimeInMilliseconds,
-            "rvn", false, Optional.empty(), null);
+            "rvn", false, Optional.empty(), null, Optional.empty());
         client.sendHeartbeat(SendHeartbeatOptions.builder(item)
             .withDeleteData(null)
             .withData(ByteBuffer.wrap("data".getBytes()))
@@ -513,7 +513,7 @@ public class AmazonDynamoDBLockClientTest {
         String partitionKey = "partition_key";
         LockItem item = new LockItem(client, partitionKey, Optional.empty(), Optional.of(ByteBuffer.wrap("data1".getBytes())),
             false, uuid.toString(), 1L, lastUpdatedTimeInMilliseconds,
-            "rvn", false, Optional.empty(), null);
+            "rvn", false, Optional.empty(), null, Optional.empty());
         assertTrue(item.getData().isPresent());
         ByteBuffer updated = ByteBuffer.wrap("data2".getBytes());
         client.sendHeartbeat(SendHeartbeatOptions.builder(item)
@@ -536,7 +536,7 @@ public class AmazonDynamoDBLockClientTest {
         long lastUpdatedTimeInMilliseconds = LockClientUtils.INSTANCE.millisecondTime();
         LockItem item = new LockItem(client, "a", Optional.empty(), Optional.of(ByteBuffer.wrap("data".getBytes())),
                 false, uuid.toString(), 10000L, lastUpdatedTimeInMilliseconds,
-                "rvn", false, Optional.empty(), null);
+                "rvn", false, Optional.empty(), null, Optional.empty());
 
         AwsServiceException amazonServiceException = null;
         try {
@@ -564,7 +564,7 @@ public class AmazonDynamoDBLockClientTest {
         long lastUpdatedTimeInMilliseconds = LockClientUtils.INSTANCE.millisecondTime();
         LockItem lockItem = new LockItem(client, "a", Optional.empty(), Optional.of(ByteBuffer.wrap("data".getBytes())),
                 false, uuid.toString(), leaseDuration, lastUpdatedTimeInMilliseconds,
-                recordVersionNumber, false, Optional.empty(), null);
+                recordVersionNumber, false, Optional.empty(), null, Optional.empty());
 
         // Setting up a spy mock to inspect the method on lockItem object created above
         LockItem lockItemSpy = PowerMockito.spy(lockItem);

--- a/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.dynamodbv2;
 
+import com.amazonaws.services.dynamodbv2.model.LockCurrentlyUnavailableException;
 import com.amazonaws.services.dynamodbv2.model.LockNotGrantedException;
 import com.amazonaws.services.dynamodbv2.model.LockTableDoesNotExistException;
 import com.amazonaws.services.dynamodbv2.model.SessionMonitorNotSetException;
@@ -45,6 +46,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
@@ -1486,7 +1488,7 @@ public class BasicLockClientTests extends InMemoryLockClientTester {
     public void testLockItemToString() throws LockNotGrantedException, InterruptedException {
         final LockItem lockItem = this.lockClient.acquireLock(ACQUIRE_LOCK_OPTIONS_TEST_KEY_1);
         final Pattern p = Pattern.compile("LockItem\\{Partition Key=testKey1, Sort Key=Optional.empty, Owner Name=" + INTEGRATION_TESTER + ", Lookup Time=\\d+, Lease Duration=3000, "
-            + "Record Version Number=\\w+-\\w+-\\w+-\\w+-\\w+, Delete On Close=true, Data=" + TEST_DATA + ", Is Released=false\\}");
+            + "Record Version Number=\\w+-\\w+-\\w+-\\w+-\\w+, Delete On Close=true, Data=" + TEST_DATA + ", Is Released=false, Last touched at=Optional\\.empty\\}");
         assertTrue(p.matcher(lockItem.toString()).matches());
     }
 
@@ -1687,6 +1689,95 @@ public class BasicLockClientTests extends InMemoryLockClientTester {
 
         final GetItemRequest getRequest = getRequestCaptor.getValue();
         final PutItemRequest putRequest = putRequestCaptor.getValue();
+    }
+
+    @Test
+    public void testUpperClockSkewErrorBoundWithNoHeartbeats() throws InterruptedException {
+        final long leaseDuration = 1_000;
+        final long clockSkewErrorBound = 500L;
+        final String partition = "super_key_LOCK";
+
+        AcquireLockOptions lockOptions = AcquireLockOptions
+          .builder(partition)
+          .withAcquireReleasedLocksConsistently(true)
+          .withShouldSkipBlockingWait(true)
+          .withClockSkewUpperBound(clockSkewErrorBound)
+          .build();
+
+        AmazonDynamoDBLockClient lockClientOne = new AmazonDynamoDBLockClient(
+          new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, TABLE_NAME, INTEGRATION_TESTER_2)
+            .withLeaseDuration(leaseDuration)
+            .withTimeUnit(TimeUnit.MILLISECONDS)
+            .withCreateHeartbeatBackgroundThread(false)
+            .build());
+
+        AmazonDynamoDBLockClient lockClientTwo = new AmazonDynamoDBLockClient(
+          new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, TABLE_NAME, INTEGRATION_TESTER_2)
+            .withLeaseDuration(leaseDuration)
+            .withTimeUnit(TimeUnit.MILLISECONDS)
+            .withCreateHeartbeatBackgroundThread(false)
+            .build());
+
+        // Acquire lock successfully. Note the lack of heartbeats.
+        LockItem lockItem = lockClientOne.acquireLock(lockOptions);
+        assertNotNull(lockItem);
+
+        // Fail to acquire as we have only waited  half the upper error bound.
+        Thread.sleep(leaseDuration + clockSkewErrorBound / 2);
+        assertThrows(LockCurrentlyUnavailableException.class, () -> lockClientTwo.acquireLock(lockOptions));
+
+        // Success since we've waited 1.5 * the error bound now!
+        Thread.sleep(clockSkewErrorBound);
+        lockItem = lockClientTwo.acquireLock(lockOptions);
+        assertNotNull(lockItem);
+    }
+
+    @Test
+    public void testUpperClockSkewErrorBoundWithHeartbeats() throws InterruptedException, NoSuchFieldException, IllegalAccessException {
+        final long leaseDuration = 1_000;
+        final long clockSkewErrorBound = 500L;
+        final String partition = "super_key_LOCK";
+
+        AcquireLockOptions lockOptions = AcquireLockOptions
+          .builder(partition)
+          .withAcquireReleasedLocksConsistently(true)
+          .withShouldSkipBlockingWait(true)
+          .withClockSkewUpperBound(clockSkewErrorBound)
+          .build();
+
+        AmazonDynamoDBLockClient lockClientOne = new AmazonDynamoDBLockClient(
+          new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, TABLE_NAME, INTEGRATION_TESTER_2)
+            .withLeaseDuration(leaseDuration)
+            .withTimeUnit(TimeUnit.MILLISECONDS)
+            .withCreateHeartbeatBackgroundThread(false)
+            .build());
+
+        AmazonDynamoDBLockClient lockClientTwo = new AmazonDynamoDBLockClient(
+          new AmazonDynamoDBLockClientOptions.AmazonDynamoDBLockClientOptionsBuilder(this.dynamoDBMock, TABLE_NAME, INTEGRATION_TESTER_2)
+            .withLeaseDuration(leaseDuration)
+            .withTimeUnit(TimeUnit.MILLISECONDS)
+            .withCreateHeartbeatBackgroundThread(false)
+            .build());
+
+        // Acquire lock successfully. Note the lack of heartbeats.
+        LockItem lockItem = lockClientOne.acquireLock(lockOptions);
+        assertNotNull(lockItem);
+
+        // Sleep a total of 2 lease durations.
+        Thread.sleep(leaseDuration / 2);
+        lockItem.sendHeartBeat();
+        Thread.sleep(leaseDuration / 2);
+        lockItem.sendHeartBeat();
+        Thread.sleep(leaseDuration / 2);
+        lockItem.sendHeartBeat();
+        Thread.sleep(leaseDuration / 2);
+        // We need to wait another lease duration / 2 + clock skew error bound for another client
+        // to acquire the lock!
+        assertThrows(LockCurrentlyUnavailableException.class, () -> lockClientTwo.acquireLock(lockOptions));
+
+        Thread.sleep(leaseDuration);
+        lockItem = lockClientTwo.acquireLock(lockOptions);
+        assertNotNull(lockItem);
     }
 
     private LockItem getShortLeaseLock() throws InterruptedException {

--- a/src/test/java/com/amazonaws/services/dynamodbv2/LockItemTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/LockItemTest.java
@@ -70,7 +70,7 @@ public class LockItemTest {
             "recordVersionNumber",
             false, //released
             Optional.of(new SessionMonitor(1000, Optional.empty())), //session monitor
-            new HashMap<>())));
+            new HashMap<>(), Optional.empty())));
     }
 
     @Test
@@ -85,7 +85,7 @@ public class LockItemTest {
             "recordVersionNumber",
             false, //released
             Optional.of(new SessionMonitor(1000, Optional.empty())), //session monitor
-            new HashMap<>())));
+            new HashMap<>(), Optional.empty())));
     }
 
     @Test
@@ -105,7 +105,7 @@ public class LockItemTest {
             "recordVersionNumber",
             true, //released
             Optional.of(new SessionMonitor(1000, Optional.empty())), //session monitor
-            new HashMap<>()).isExpired());
+            new HashMap<>(), Optional.empty()).isExpired());
     }
 
     @Test
@@ -125,7 +125,7 @@ public class LockItemTest {
             "recordVersionNumber",
             true, //released
             Optional.empty(), //session monitor
-            new HashMap<>()).ensure(2L, TimeUnit.MILLISECONDS);
+            new HashMap<>(), Optional.empty()).ensure(2L, TimeUnit.MILLISECONDS);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -140,7 +140,7 @@ public class LockItemTest {
             "recordVersionNumber",
             true, //released
             Optional.of(new SessionMonitor(1000, Optional.empty())), //session monitor
-            new HashMap<>()).millisecondsUntilDangerZoneEntered();
+            new HashMap<>(), Optional.empty()).millisecondsUntilDangerZoneEntered();
     }
 
     @Test
@@ -167,7 +167,7 @@ public class LockItemTest {
             "recordVersionNumber",
             false, //released
             Optional.empty(), //session monitor
-            new HashMap<>()).hasCallback();
+            new HashMap<>(), Optional.empty()).hasCallback();
     }
 
     @Test
@@ -192,6 +192,6 @@ public class LockItemTest {
             "recordVersionNumber",
             false, //released
             Optional.of(new SessionMonitor(1000, Optional.empty())), //session monitor
-            new HashMap<>()); //additional attributes
+            new HashMap<>(), Optional.empty()); //additional attributes
     }
 }


### PR DESCRIPTION
This commit addresses issue #44 by providing a new option to utilize wall clock time along with a provided error bound to determine if a lock is expired.

Previously it was impossible to determine if a lease was expired without blocking for at least lease duration and seeing if the version had changed. Thus, if you never block and the lease wasn't explicitly marked as released then the lock was unable to ever be acquired again. By providing a correct upper clock skew error bound clients can correctly take over locks which have expired but not been explicitly released without blocking.

In most distributed systems relying on wall clock time is generally not correct but in this case we can provide an upper clock skew error bound on the scale of minutes without facing any negative consequences for most clients. This tradeoff of having a lease be unacquireable for several minutes is possibly better than being forced to block in many use cases.