### PR TITLE
Synchonized Migration and Thread Creation Overrides (Support for Virtual Threads)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>dynamodb-lock-client</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <packaging>jar</packaging>
     <name>Amazon DynamoDB Lock Client</name>
     <url>https://github.com/awslabs/amazon-dynamodb-lock-client</url>

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -236,6 +237,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
     private final ConcurrentHashMap<String, Thread> sessionMonitors;
     private final Optional<Thread> backgroundThread;
     private final Function<String, ThreadFactory> namedThreadCreator;
+    private final ReentrantLock releaseLocksReentrantLock;
     private volatile boolean shuttingDown = false;
 
     /* These are the keys that are stored in the DynamoDB table to keep track of the locks */
@@ -280,6 +282,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
         this.sortKeyName = amazonDynamoDBLockClientOptions.getSortKeyName();
         this.namedThreadCreator = amazonDynamoDBLockClientOptions.getNamedThreadCreator();
         this.holdLockOnServiceUnavailable = amazonDynamoDBLockClientOptions.getHoldLockOnServiceUnavailable();
+        this.releaseLocksReentrantLock = new ReentrantLock();
 
         if (amazonDynamoDBLockClientOptions.getCreateHeartbeatBackgroundThread()) {
             if (this.leaseDurationInMilliseconds < 2 * this.heartbeatPeriodInMilliseconds) {
@@ -833,7 +836,9 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
             return false;
         }
 
-        synchronized (lockItem) {
+        lockItem.getReentrantLock().lock();
+        try
+        {
             try {
                 // Always remove the heartbeat for the lock. The
                 // caller's intention is to release the lock. Stopping the
@@ -911,6 +916,12 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
             // get exceptions from this method.
             this.removeKillSessionMonitor(lockItem.getUniqueIdentifier());
         }
+        finally
+        {
+            lockItem.getReentrantLock()
+                    .unlock();
+        }
+
         return true;
     }
 
@@ -932,10 +943,14 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
      */
     private void releaseAllLocks() {
         final Map<String, LockItem> locks = new HashMap<>(this.locks);
-        synchronized (locks) {
+        this.releaseLocksReentrantLock.lock();
+        try {
             for (final Entry<String, LockItem> lockEntry : locks.entrySet()) {
                 this.releaseLock(lockEntry.getValue()); // TODO catch exceptions and report failure separately
             }
+        }
+        finally {
+            this.releaseLocksReentrantLock.unlock();
         }
     }
 
@@ -1143,7 +1158,8 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
             throw new LockNotGrantedException("Cannot send heartbeat because lock is not granted");
         }
 
-        synchronized (lockItem) {
+        lockItem.getReentrantLock().lock();
+        try {
             //Set up condition for UpdateItem. Basically any changes require:
             //1. I own the lock
             //2. I know the current version number
@@ -1214,6 +1230,10 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
                     throw awsServiceException;
                 }
             }
+        }
+        finally {
+            lockItem.getReentrantLock()
+                    .unlock();
         }
     }
 

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientOptions.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientOptions.java
@@ -75,6 +75,14 @@ public class AmazonDynamoDBLockClientOptions {
                 namedThreadCreator());
         }
 
+        AmazonDynamoDBLockClientOptionsBuilder(final DynamoDbClient dynamoDBClient, final String tableName, final Function<String, ThreadFactory> namedThreadCreator) {
+            this(dynamoDBClient, tableName,
+                    /* By default, tries to set ownerName to the localhost */
+                    generateOwnerNameFromLocalhost(),
+                    namedThreadCreator);
+        }
+
+
         private static final String generateOwnerNameFromLocalhost() {
             try {
                 return Inet4Address.getLocalHost().getHostName() + UUID.randomUUID().toString();
@@ -181,18 +189,6 @@ public class AmazonDynamoDBLockClientOptions {
         }
 
         /**
-         * Specifies the named thread creator. This is useful for setting up thread names for the heartbeat threads, as
-         * well as for overriding the default thread factory. For example, this can be used to utilize virtual threads.
-         *
-         * @param namedThreadCreator A function that takes in a thread name and outputs a ThreadFactory that creates threads with the given name.
-         * @return a reference to this builder for fluent method chaining
-         */
-        public AmazonDynamoDBLockClientOptionsBuilder withNamedThreadCreator(final Function<String, ThreadFactory> namedThreadCreator) {
-            this.namedThreadCreator = namedThreadCreator;
-            return this;
-        }
-
-        /**
          * This parameter should be set to true only in the applications which do not have strict locking requirements.
          * When this is set to true, on DynamoDB service unavailable errors it is possible that two different clients can hold the lock.
          *
@@ -242,6 +238,20 @@ public class AmazonDynamoDBLockClientOptions {
      */
     public static AmazonDynamoDBLockClientOptionsBuilder builder(final DynamoDbClient dynamoDBClient, final String tableName) {
         return new AmazonDynamoDBLockClientOptionsBuilder(dynamoDBClient, tableName);
+    }
+
+    /**
+     * Creates an AmazonDynamoDBLockClientOptions builder object, which can be
+     * used to create an AmazonDynamoDBLockClient. The only required parameters
+     * are the client and the table name.
+     *
+     * @param dynamoDBClient The client for talking to DynamoDB.
+     * @param tableName      The table containing the lock client.
+     * @param namedThreadCreator A function that takes in a thread name and outputs a ThreadFactory that creates threads with the given name.
+     * @return A builder which can be used for creating a lock client.
+     */
+    public static AmazonDynamoDBLockClientOptionsBuilder builder(final DynamoDbClient dynamoDBClient, final String tableName, final Function<String, ThreadFactory> namedThreadCreator) {
+        return new AmazonDynamoDBLockClientOptionsBuilder(dynamoDBClient, tableName, namedThreadCreator);
     }
 
     private AmazonDynamoDBLockClientOptions(final DynamoDbClient dynamoDBClient, final String tableName, final String partitionKeyName, final Optional<String> sortKeyName,

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientOptions.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientOptions.java
@@ -51,7 +51,6 @@ public class AmazonDynamoDBLockClientOptions {
     private final Function<String, ThreadFactory> namedThreadCreator;
     private final Boolean holdLockOnServiceUnavailable;
 
-
     /**
      * A builder for setting up an AmazonDynamoDBLockClientOptions object. By default, it is setup to have a partition key name of
      * "key," a lease duration of 20 seconds, and a default heartbeat period of 5 seconds. These defaults can be overriden.
@@ -178,6 +177,18 @@ public class AmazonDynamoDBLockClientOptions {
          */
         public AmazonDynamoDBLockClientOptionsBuilder withCreateHeartbeatBackgroundThread(final Boolean createHeartbeatBackgroundThread) {
             this.createHeartbeatBackgroundThread = createHeartbeatBackgroundThread;
+            return this;
+        }
+
+        /**
+         * Specifies the named thread creator. This is useful for setting up thread names for the heartbeat threads, as
+         * well as for overriding the default thread factory. For example, this can be used to utilize virtual threads.
+         *
+         * @param namedThreadCreator A function that takes in a thread name and outputs a ThreadFactory that creates threads with the given name.
+         * @return a reference to this builder for fluent method chaining
+         */
+        public AmazonDynamoDBLockClientOptionsBuilder withNamedThreadCreator(final Function<String, ThreadFactory> namedThreadCreator) {
+            this.namedThreadCreator = namedThreadCreator;
             return this;
         }
 

--- a/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
@@ -26,6 +26,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
 /**
@@ -37,6 +39,7 @@ public class LockItem implements Closeable {
     private final AmazonDynamoDBLockClient client;
     private final String partitionKey;
     private final Optional<String> sortKey;
+    private final ReentrantLock reentrantLock;
 
     private Optional<ByteBuffer> data;
     private final String ownerName;
@@ -87,6 +90,7 @@ public class LockItem implements Closeable {
         this.ownerName = ownerName;
         this.deleteLockItemOnClose = deleteLockItemOnClose;
 
+        this.reentrantLock = new ReentrantLock();
         this.leaseDuration = new AtomicLong(leaseDuration);
         this.lookupTime = new AtomicLong(lastUpdatedTimeInMilliseconds);
         this.recordVersionNumber = new StringBuffer(recordVersionNumber);
@@ -103,6 +107,15 @@ public class LockItem implements Closeable {
      */
     public String getPartitionKey() {
         return this.partitionKey;
+    }
+
+    /**
+     * Returns the {@link ReentrantLock} for this {@link LockItem}.
+     *
+     * @return The reentrant lock for this lock item.
+     */
+    public ReentrantLock getReentrantLock() {
+        return this.reentrantLock;
     }
 
     /**

--- a/src/test/java/com/amazonaws/services/dynamodbv2/LockItemTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/LockItemTest.java
@@ -69,7 +69,7 @@ public class LockItemTest {
             1000, //last updated time in milliseconds
             "recordVersionNumber",
             false, //released
-            Optional.of(new SessionMonitor(1000, Optional.empty())), //session monitor
+            Optional.of(new SessionMonitor(1000, Optional.empty(), Thread::new)), //session monitor
             new HashMap<>())));
     }
 
@@ -84,7 +84,7 @@ public class LockItemTest {
             1000, //last updated time in milliseconds
             "recordVersionNumber",
             false, //released
-            Optional.of(new SessionMonitor(1000, Optional.empty())), //session monitor
+            Optional.of(new SessionMonitor(1000, Optional.empty(), Thread::new)), //session monitor
             new HashMap<>())));
     }
 
@@ -104,7 +104,7 @@ public class LockItemTest {
             1000, //last updated time in milliseconds
             "recordVersionNumber",
             true, //released
-            Optional.of(new SessionMonitor(1000, Optional.empty())), //session monitor
+            Optional.of(new SessionMonitor(1000, Optional.empty(), Thread::new)), //session monitor
             new HashMap<>()).isExpired());
     }
 
@@ -139,7 +139,7 @@ public class LockItemTest {
             1000, //last updated time in milliseconds
             "recordVersionNumber",
             true, //released
-            Optional.of(new SessionMonitor(1000, Optional.empty())), //session monitor
+            Optional.of(new SessionMonitor(1000, Optional.empty(), Thread::new)), //session monitor
             new HashMap<>()).millisecondsUntilDangerZoneEntered();
     }
 
@@ -191,7 +191,7 @@ public class LockItemTest {
             1000, //last updated time in milliseconds
             "recordVersionNumber",
             false, //released
-            Optional.of(new SessionMonitor(1000, Optional.empty())), //session monitor
+            Optional.of(new SessionMonitor(1000, Optional.empty(), Thread::new)), //session monitor
             new HashMap<>()); //additional attributes
     }
 }

--- a/src/test/java/com/amazonaws/services/dynamodbv2/SessionMonitorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/SessionMonitorTest.java
@@ -36,33 +36,33 @@ import org.powermock.modules.junit4.PowerMockRunner;
 public class SessionMonitorTest {
     @Test
     public void isLeaseEnteringDangerZone_whenThereAreZeroOrLessMillisUntilEnterDangerZone_returnTrue() {
-        SessionMonitor sut = PowerMockito.spy(new SessionMonitor(1000, Optional.empty()));
+        SessionMonitor sut = PowerMockito.spy(new SessionMonitor(1000, Optional.empty(), Thread::new));
         when(sut.millisecondsUntilLeaseEntersDangerZone(25L)).thenReturn(0L);
         assertTrue(sut.isLeaseEnteringDangerZone(25L));
     }
 
     @Test
     public void isLeaseEnteringDangerZone_whenThereAreMoreThanZeroMillisUntilEnterDangerZone_returnFalse() {
-        SessionMonitor sut = PowerMockito.spy(new SessionMonitor(1000, Optional.empty()));
+        SessionMonitor sut = PowerMockito.spy(new SessionMonitor(1000, Optional.empty(), Thread::new));
         when(sut.millisecondsUntilLeaseEntersDangerZone(25L)).thenReturn(1L);
         assertFalse(sut.isLeaseEnteringDangerZone(25L));
     }
 
     @Test
     public void runCallback_whenNotPresent_doesNothing() {
-        SessionMonitor sut = new SessionMonitor(1000, Optional.empty());
+        SessionMonitor sut = new SessionMonitor(1000, Optional.empty(), Thread::new);
         sut.runCallback();
     }
 
     @Test
     public void hasCallback_whenCallbackNull_returnFalse() {
-        SessionMonitor sut = new SessionMonitor(1000, null);
+        SessionMonitor sut = new SessionMonitor(1000, null, Thread::new);
         assertFalse(sut.hasCallback());
     }
 
     @Test
     public void hasCallback_whenCallbackNotNull_returnTrue() {
-        SessionMonitor sut = new SessionMonitor(1000, Optional.empty());
+        SessionMonitor sut = new SessionMonitor(1000, Optional.empty(), Thread::new);
         assertTrue(sut.hasCallback());
     }
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* A migration from use of synchronized blocks to ReentrantLocks, in order to avoid virtual thread pinning. This change also adds support for overriding thread creation, so that virtual threads may be utilized.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
