### PR TITLE
Fix test coverage and update maven version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>dynamodb-lock-client</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <packaging>jar</packaging>
     <name>Amazon DynamoDB Lock Client</name>
     <url>https://github.com/awslabs/amazon-dynamodb-lock-client</url>

--- a/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
@@ -464,7 +464,7 @@ public class AmazonDynamoDBLockClientTest {
         item.put("leaseDuration", AttributeValue.builder().s("100").build());
         when(dynamodb.getItem(Mockito.<GetItemRequest>any()))
             .thenReturn(GetItemResponse.builder().item(item).build())
-            .thenReturn(GetItemResponse.builder().build());
+            .thenReturn(GetItemResponse.builder().item(item).build());
         AcquireLockOptions acquireLockOptions = AcquireLockOptions.builder("customer1")
             .withShouldSkipBlockingWait(true)
             .withDeleteLockOnRelease(false).build();


### PR DESCRIPTION
*Description of changes:*
Fixes test coverage issue that arises after merge of #88. Test was not actually covering the scenario where a lease is lapsed. We want to test the scenario where the same lock item comes back twice with the same id. Previous test was getting an empty lock back the second time, so lease duration wasn't being considered. 

Upgrades Maven version (need to confirm)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
