### PR TITLE
Update additional attributes on lock release

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
@@ -52,6 +52,7 @@ import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
 import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
@@ -907,6 +908,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
                             .tableName(this.tableName)
                             .key(key)
                             .updateExpression(updateExpression)
+                            .attributeUpdates(options.getAdditionalAttributeUpdates())
                             .conditionExpression(conditionalExpression)
                             .expressionAttributeNames(expressionAttributeNames)
                             .expressionAttributeValues(expressionAttributeValues).build();

--- a/src/main/java/com/amazonaws/services/dynamodbv2/ReleaseLockOptions.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/ReleaseLockOptions.java
@@ -14,7 +14,11 @@
  */
 package com.amazonaws.services.dynamodbv2;
 
+import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate;
+
 import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -28,25 +32,29 @@ public class ReleaseLockOptions {
     private final boolean deleteLock;
     private final boolean bestEffort;
     private final Optional<ByteBuffer> data;
+    private final Map<String, AttributeValueUpdate> additionalAttributeUpdates;
 
-    ReleaseLockOptions(final LockItem lockItem, final boolean deleteLock, final boolean bestEffort, final Optional<ByteBuffer> data) {
+    ReleaseLockOptions(final LockItem lockItem, final boolean deleteLock, final boolean bestEffort, final Optional<ByteBuffer> data, Map<String, AttributeValueUpdate> additionalAttributeUpdates) {
         this.lockItem = lockItem;
         this.deleteLock = deleteLock;
         this.bestEffort = bestEffort;
         this.data = data;
+        this.additionalAttributeUpdates = additionalAttributeUpdates;
     }
 
     public static class ReleaseLockOptionsBuilder {
-        private LockItem lockItem;
+        private final LockItem lockItem;
         private boolean deleteLock;
         private boolean bestEffort;
         private Optional<ByteBuffer> data;
+        private Map<String, AttributeValueUpdate> additionalAttributeUpdates;
 
         ReleaseLockOptionsBuilder(final LockItem lockItem) {
             this.lockItem = lockItem;
             this.deleteLock = true;
             this.bestEffort = false;
             this.data = Optional.empty();
+            this.additionalAttributeUpdates = new HashMap<>();
         }
 
         /**
@@ -90,14 +98,25 @@ public class ReleaseLockOptions {
             return this;
         }
 
+        /**
+         * Stores some additional attributes with the lock. This can be used to add/update any arbitrary parameters to
+         * the lock row.
+         *
+         * @param additionalAttributeUpdates an arbitrary map of attribute updates to store with the lock row to be acquired
+         * @return a reference to this builder for fluent method chaining
+         */
+        public ReleaseLockOptionsBuilder withAdditionalAttributeUpdates(Map<String, AttributeValueUpdate> additionalAttributeUpdates) {
+            this.additionalAttributeUpdates = additionalAttributeUpdates;
+            return this;
+        }
+
         public ReleaseLockOptions build() {
-            return new ReleaseLockOptions(this.lockItem, this.deleteLock, this.bestEffort, this.data);
+            return new ReleaseLockOptions(this.lockItem, this.deleteLock, this.bestEffort, this.data, this.additionalAttributeUpdates);
         }
 
         @Override
-        public java.lang.String toString() {
-            return "ReleaseLockOptions.ReleaseLockOptionsBuilder(lockItem=" + this.lockItem + ", deleteLock=" + this.deleteLock + ", bestEffort=" + this.bestEffort + ", data="
-                + this.data + ")";
+        public String toString() {
+            return String.format("ReleaseLockOptions.ReleaseLockOptionsBuilder(lockItem=%s, deleteLock=%s, bestEffort=%s, data=%s, additionalAttributeUpdates=%s)", lockItem, deleteLock, bestEffort, data, additionalAttributeUpdates);
         }
     }
 
@@ -128,5 +147,9 @@ public class ReleaseLockOptions {
 
     Optional<ByteBuffer> getData() {
         return this.data;
+    }
+
+    Map<String, AttributeValueUpdate> getAdditionalAttributeUpdates() {
+        return additionalAttributeUpdates;
     }
 }

--- a/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
@@ -1540,6 +1540,44 @@ public class BasicLockClientTests extends InMemoryLockClientTester {
                 .build());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidAttributeUpdatesData() throws LockNotGrantedException, InterruptedException {
+        this.testInvalidAttributeUpdate("data");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidAttributeUpdatesKey() throws LockNotGrantedException, InterruptedException {
+        this.testInvalidAttributeUpdate("key");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidAttributeUpdatesLeaseDuration() throws LockNotGrantedException, InterruptedException {
+        this.testInvalidAttributeUpdate("leaseDuration");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidAttributeUpdatesRecordVersionNumber() throws LockNotGrantedException, InterruptedException {
+        this.testInvalidAttributeUpdate("recordVersionNumber");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidAttributeUpdatesOwnerName() throws LockNotGrantedException, InterruptedException {
+        this.testInvalidAttributeUpdate("ownerName");
+    }
+
+    private void testInvalidAttributeUpdate(final String invalidAttribute) throws InterruptedException {
+        final LockItem item = this.lockClient.acquireLock(AcquireLockOptions.builder("testKey1").build());
+
+        final Map<String, AttributeValueUpdate> additionalAttributeUpdates = new HashMap<>();
+        additionalAttributeUpdates.put(
+                invalidAttribute,
+                AttributeValueUpdate.builder().value(AttributeValue.fromS("ok")).build()
+        );
+        this.lockClient.releaseLock(
+                ReleaseLockOptions.builder(item).withAdditionalAttributeUpdates(additionalAttributeUpdates).build()
+        );
+    }
+
     @Test
     public void testLockItemToString() throws LockNotGrantedException, InterruptedException {
         final LockItem lockItem = this.lockClient.acquireLock(ACQUIRE_LOCK_OPTIONS_TEST_KEY_1);

--- a/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/BasicLockClientTests.java
@@ -34,6 +34,7 @@ import org.mockito.Mockito;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValueUpdate;
 import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
@@ -45,6 +46,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doReturn;
@@ -1002,7 +1004,7 @@ public class BasicLockClientTests extends InMemoryLockClientTester {
     }
 
     @Test
-    public void testSendHeatbeatWithRangeKey() throws IOException, LockNotGrantedException, InterruptedException {
+    public void testSendHeartbeatWithRangeKey() throws IOException, LockNotGrantedException, InterruptedException {
 
         final String data = new String("testSendHeartbeatLeaveData" + SECURE_RANDOM.nextDouble());
 
@@ -1120,6 +1122,62 @@ public class BasicLockClientTests extends InMemoryLockClientTester {
         item = this.lockClient.acquireLock(AcquireLockOptions.builder("testKey1")
                 .withDeleteLockOnRelease(false).withReplaceData(false).build());
         assertEquals("newData", byteBufferToString(item.getData().get()));
+
+        item.close();
+    }
+
+    @Test
+    public void testReleaseLockLeaveItemAndChangeAttributes() throws LockNotGrantedException, InterruptedException {
+        final String lockTypeAttributeName = "LockType";
+        final String boreDiameterAttributeName = "BoreDiameter";
+
+        final AttributeValue initialLockType = AttributeValue.fromS("Mortise");
+
+        final Map<String, AttributeValue> additionalAttributes = new HashMap<>();
+        additionalAttributes.put(lockTypeAttributeName, initialLockType);
+
+        LockItem item = this.lockClient.acquireLock(
+                AcquireLockOptions.builder("testKey1")
+                        .withAdditionalAttributes(additionalAttributes)
+                        .withDeleteLockOnRelease(false)
+                        .withReplaceData(true)
+                        .build()
+        );
+        assertEquals(initialLockType, item.getAdditionalAttributes().get(lockTypeAttributeName));
+        assertNull(item.getAdditionalAttributes().get(boreDiameterAttributeName));
+
+        final AttributeValue updatedLockType = AttributeValue.fromS("Deadbolt");
+
+        final AttributeValue boreDiameter = AttributeValue.fromN("55");
+
+        final Map<String, AttributeValueUpdate> additionalAttributeUpdates = new HashMap<>();
+        additionalAttributeUpdates.put(
+                lockTypeAttributeName,
+                AttributeValueUpdate.builder().value(updatedLockType).build()
+        );
+        additionalAttributeUpdates.put(
+                boreDiameterAttributeName,
+                AttributeValueUpdate.builder().value(boreDiameter).build()
+        );
+
+        this.lockClient.releaseLock(
+                ReleaseLockOptions.builder(item)
+                        .withDeleteLock(false)
+                        .withAdditionalAttributeUpdates(additionalAttributeUpdates)
+                        .build()
+        );
+
+        assertEquals(Optional.empty(), this.lockClient.getLock("testKey1", Optional.empty()));
+
+        item = this.lockClient.getLockFromDynamoDB(GET_LOCK_OPTIONS_DO_NOT_DELETE_ON_RELEASE).get();
+        assertTrue(item.isReleased());
+        assertEquals(updatedLockType, item.getAdditionalAttributes().get(lockTypeAttributeName));
+        assertEquals(boreDiameter, item.getAdditionalAttributes().get(boreDiameterAttributeName));
+
+        item = this.lockClient.acquireLock(AcquireLockOptions.builder("testKey1")
+                .withDeleteLockOnRelease(false).withReplaceData(false).build());
+        assertEquals(updatedLockType, item.getAdditionalAttributes().get(lockTypeAttributeName));
+        assertEquals(boreDiameter, item.getAdditionalAttributes().get(boreDiameterAttributeName));
 
         item.close();
     }


### PR DESCRIPTION
Allows for users to make changes to attributes on releasing a lock.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
