### PR TITLE
Bump version to 1.4.0 and update dependencies for Maven Central publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ this artifact in Maven in your pom.xml.
 <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>dynamodb-lock-client</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>dynamodb-lock-client</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <packaging>jar</packaging>
     <name>Amazon DynamoDB Lock Client</name>
     <url>https://github.com/awslabs/amazon-dynamodb-lock-client</url>
@@ -41,15 +41,15 @@
         <maven.compiler.plugin.version>3.8.0</maven.compiler.plugin.version>
         <maven.dependency.plugin.version>3.1.1</maven.dependency.plugin.version>
         <maven.enforcer.plugin.version>3.0.0-M2</maven.enforcer.plugin.version>
-        <maven.gpg.plugin.version>1.6</maven.gpg.plugin.version>
+        <maven.gpg.plugin.version>3.0.1</maven.gpg.plugin.version>
         <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
         <maven.resources.plugin.version>3.1.0</maven.resources.plugin.version>
         <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
 
         <!-- compile dependencies -->
-        <aws.java.sdk.version>2.20.8</aws.java.sdk.version>
+        <aws.java.sdk.version>2.32.10</aws.java.sdk.version>
         <netty.version>[4.1.89.Final,)</netty.version>
-        <commons-logging.version>1.2</commons-logging.version>
+        <commons-logging.version>1.3.5</commons-logging.version>
 
         <!-- test dependencies -->
         <dynamodblocal.version>1.21.0</dynamodblocal.version>
@@ -70,7 +70,7 @@
         <!-- code quality tools -->
         <maven.checkstyle.plugin.version>3.0.0</maven.checkstyle.plugin.version>
         <spotbugs-maven-plugin.version>3.1.10</spotbugs-maven-plugin.version>
-        <jacoco.version>0.8.2</jacoco.version>
+        <jacoco.version>0.8.11</jacoco.version>
         <jacoco.it.execution.data.file>${project.build.directory}/coverage-reports/jacoco-it.exec</jacoco.it.execution.data.file>
         <jacoco.ut.execution.data.file>${project.build.directory}/coverage-reports/jacoco-ut.exec</jacoco.ut.execution.data.file>
         <jacoco-aggregate-destFile>${project.build.directory}/coverage-reports/aggregate.exec</jacoco-aggregate-destFile>
@@ -269,6 +269,12 @@
                 <artifactId>byte-buddy</artifactId>
                 <version>${bytebuddy.version}</version>
             </dependency>
+            <dependency>
+                <!--Force httpcore version to resolve dependency convergence issue-->
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>4.4.16</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
     <build>
@@ -465,6 +471,15 @@
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>${maven.resources.plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <profiles>
@@ -479,6 +494,7 @@
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>jar-no-fork</goal>
                                 </goals>
@@ -492,6 +508,7 @@
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>
+                                <phase>package</phase>
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
@@ -511,6 +528,12 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -584,12 +607,12 @@
     </profiles>
     <distributionManagement>
         <snapshotRepository>
-            <id>aws</id>
-            <url>https://aws.oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>aws</id>
-            <url>https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>central</id>
+            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
Description:

Issue #, if available: N/A

Description of changes:

This PR updates the repository to align with the 1.4.0 release that was [published to Maven Central on 2025-07-30](https://central.sonatype.com/artifact/com.amazonaws/
dynamodb-lock-client/1.4.0).

Version bump:
- Project version: 1.3.0 → 1.4.0 (in pom.xml and README.md)

Dependency upgrades:
- AWS Java SDK: 2.20.8 → 2.32.10
- commons-logging: 1.2 → 1.3.5
- JaCoCo: 0.8.2 → 0.8.11
- maven-gpg-plugin: 1.6 → 3.0.1

New dependencies:
- Added org.apache.httpcomponents:httpcore:4.4.16 to resolve dependency convergence issues

Build & publishing changes:
- Added central-publishing-maven-plugin (v0.8.0) for Sonatype Central publishing
- Added GPG --pinentry-mode loopback configuration for non-interactive signing
- Added phase: package to source and javadoc jar executions
- Migrated distribution management URLs from aws.oss.sonatype.org to ossrh-staging-api.central.sonatype.com

Testing:
- N/A — version/dependency-only changes, no logic modifications

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
