### PR TITLE
Fix skip-blocking stale lock handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,14 @@ releaseLock() or lockItem.close()
 ### Acquire lock with timeout
 You can acquire a lock via two different methods: acquireLock or tryAcquireLock. The difference between the
 two methods is that tryAcquireLock will return Optional.absent() if the lock was not acquired, whereas
-acquireLock will throw a LockNotGrantedException. Both methods provide optional parameters where you can specify
-an additional timeout for acquiring the lock. Then they will try to acquire the lock for that amount of time
-before giving up. They do this by continually polling DynamoDB according to an interval you set up. Remember that
-acquireLock/tryAcquireLock will always poll DynamoDB for at least the leaseDuration period before giving up,
-because this is the only way it will be able to expire stale locks.
+acquireLock will throw a LockNotGrantedException. When `shouldSkipBlockingWait` is true, acquireLock can instead
+throw LockCurrentlyUnavailableException if the lock is currently held and the client did not wait long enough to
+determine that it is stale. tryAcquireLock catches both exceptions and returns Optional.absent(). Both methods
+provide optional parameters where you can specify an additional timeout for acquiring the lock. Then they will try
+to acquire the lock for that amount of time before giving up. They do this by continually polling DynamoDB according
+to an interval you set up. Remember that acquireLock/tryAcquireLock will always poll DynamoDB for at least the
+leaseDuration period before giving up, unless `shouldSkipBlockingWait` is true, because this is the only way it will
+be able to expire stale locks.
 
 This example will poll DynamoDB every second for 5 additional seconds (beyond the lease duration period),
 trying to acquire a lock:

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AcquireLockOptions.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AcquireLockOptions.java
@@ -212,6 +212,13 @@ public class AcquireLockOptions {
         /**
          * With this being true, the lock client will not block the running thread and wait for lock, rather will fast fail the request,
          * so that the caller can either choose to back-off and process the same request or start processing a new request.
+         * This only skips the blocking wait for a lock that is currently held by another owner. Other retryable failures, such as
+         * DynamoDB client exceptions or acquiring only if a missing lock already exists, may still follow the normal acquire retry
+         * behavior.
+         * A caller that repeatedly retries with the same AmazonDynamoDBLockClient instance can still acquire an otherwise stale lock
+         * once it observes the same record version number for longer than the lock lease duration.
+         * This stale-lock observation is kept in a bounded in-memory cache on the lock client. If that observation is evicted, the
+         * client must observe the same record version number again before it can acquire the stale lock with skip blocking wait enabled.
          *
          *
          * @param shouldSkipBlockingWait whether lock client should skip the logic to block the thread if lock is owned by another machine
@@ -476,4 +483,3 @@ public class AcquireLockOptions {
         return shouldSkipBlockingWait;
     }
 }
-

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
@@ -232,12 +232,43 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
     private final long heartbeatPeriodInMilliseconds;
     private final boolean holdLockOnServiceUnavailable;
     private final String ownerName;
+    private final int maxLockObservationCacheSize;
     private final ConcurrentHashMap<String, LockItem> locks;
-    private final ConcurrentHashMap<String, LockItem> notMyLocks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, LockObservation> notMyLocks = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Thread> sessionMonitors;
     private final Optional<Thread> backgroundThread;
     private final Function<String, ThreadFactory> namedThreadCreator;
     private volatile boolean shuttingDown = false;
+
+    /*
+     * A lock read from DynamoDB starts its local expiration clock at the time of that read, so a freshly-read LockItem can never
+     * prove that an unchanged RVN is already stale. For shouldSkipBlockingWait, we only need to remember when this client first
+     * observed a non-owned RVN and its lease duration. Keeping a lightweight observation avoids retaining lock data, additional
+     * attributes, session monitor state, or a full LockItem for locks this client does not own.
+     */
+    private static final class LockObservation {
+        private final String recordVersionNumber;
+        private final long lookupTimeInMilliseconds;
+        private final long leaseDurationInMilliseconds;
+
+        private LockObservation(final LockItem lockItem) {
+            this.recordVersionNumber = lockItem.getRecordVersionNumber();
+            this.lookupTimeInMilliseconds = lockItem.getLookupTime();
+            this.leaseDurationInMilliseconds = lockItem.getLeaseDuration();
+        }
+
+        private boolean isSameRecordVersion(final LockItem lockItem) {
+            return this.recordVersionNumber.equals(lockItem.getRecordVersionNumber());
+        }
+
+        private boolean isExpired() {
+            return LockClientUtils.INSTANCE.millisecondTime() - this.lookupTimeInMilliseconds > this.leaseDurationInMilliseconds;
+        }
+
+        private boolean isOlderThan(final long now, final long ageInMilliseconds) {
+            return now - this.lookupTimeInMilliseconds > ageInMilliseconds;
+        }
+    }
 
     /* These are the keys that are stored in the DynamoDB table to keep track of the locks */
     protected static final String DATA = "data";
@@ -281,6 +312,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
         this.sortKeyName = amazonDynamoDBLockClientOptions.getSortKeyName();
         this.namedThreadCreator = amazonDynamoDBLockClientOptions.getNamedThreadCreator();
         this.holdLockOnServiceUnavailable = amazonDynamoDBLockClientOptions.getHoldLockOnServiceUnavailable();
+        this.maxLockObservationCacheSize = amazonDynamoDBLockClientOptions.getMaxLockObservationCacheSize();
 
         if (amazonDynamoDBLockClientOptions.getCreateHeartbeatBackgroundThread()) {
             if (this.leaseDurationInMilliseconds < 2 * this.heartbeatPeriodInMilliseconds) {
@@ -402,6 +434,10 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
      *
      * @param options A combination of optional arguments that may be passed in for acquiring the lock
      * @return the lock
+     * @throws LockNotGrantedException if the lock is not acquired before the configured wait time elapses, or if the
+     * lock cannot be acquired because of a failed conditional write or exceeded provisioned throughput.
+     * @throws LockCurrentlyUnavailableException if {@code shouldSkipBlockingWait} is true and the lock is currently
+     * held by another owner, or if another owner acquires the lock first during a skip-blocking acquire attempt.
      * @throws InterruptedException in case the Thread.sleep call was interrupted while waiting to refresh.
      */
     @SuppressWarnings("resource") // LockItem.close() does not need to be called until the lock is acquired, so we suppress the warning here.
@@ -470,31 +506,19 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
                         throw new LockNotGrantedException("Lock does not exist.");
                     }
 
+                    boolean existingLockKnownExpired = false;
                     if (options.shouldSkipBlockingWait() && existingLock.isPresent() && !existingLock.get().isExpired()) {
-                        String id = existingLock.get().getUniqueIdentifier();
-                        // Let's check to see if this existingLock expired based on old data we cached.
-                        // Or cache it if we haven't seen this recordVersion before.
-                        boolean isReallyExpired = false;
-                        if (notMyLocks.containsKey(id) &&
-                              notMyLocks.get(id).getRecordVersionNumber()
-                              .equals(existingLock.get().getRecordVersionNumber())) {
-
-                          isReallyExpired = notMyLocks.get(id).isExpired();
-                          if (isReallyExpired) {
-                              // short circuit the waiting that we normally do.
-                              lockTryingToBeAcquired = notMyLocks.get(id);
-                          }
-                        } else {
-                            notMyLocks.put(id, existingLock.get());
-                        }
-
+                        final LockItem lockFromDynamoDB = existingLock.get();
                         /*
                          * The lock is being held by some one and is still not expired. And the caller explicitly said not to perform a blocking wait;
                          * We will throw back a lock not grant exception, so that the caller can retry if needed.
                          */
-                        if (!isReallyExpired) {
+                        existingLockKnownExpired = observedLockIsExpired(lockFromDynamoDB);
+                        if (!existingLockKnownExpired) {
                             throw new LockCurrentlyUnavailableException("The lock being requested is being held by another client.");
                         }
+                        // short circuit the waiting that we normally do.
+                        lockTryingToBeAcquired = lockFromDynamoDB;
                     }
 
                     Optional<ByteBuffer> newLockData = Optional.empty();
@@ -544,7 +568,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
                     } else {
                         if (lockTryingToBeAcquired.getRecordVersionNumber().equals(existingLock.get().getRecordVersionNumber())) {
                             /* If the version numbers match, then we can acquire the lock, assuming it has already expired */
-                            if (lockTryingToBeAcquired.isExpired()) {
+                            if (existingLockKnownExpired || lockTryingToBeAcquired.isExpired()) {
                                 return upsertAndMonitorExpiredLock(options, key, sortKey, deleteLockOnRelease, sessionMonitor, existingLock, newLockData, item,
                                     recordVersionNumber);
                             }
@@ -559,6 +583,9 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
                 } catch (final ConditionalCheckFailedException conditionalCheckFailedException) {
                     /* Someone else acquired the lock while we tried to do so, so we throw an exception */
                     logger.debug("Someone else acquired the lock", conditionalCheckFailedException);
+                    if (options.shouldSkipBlockingWait()) {
+                        throw new LockCurrentlyUnavailableException("Could not acquire lock because someone else acquired it: ", conditionalCheckFailedException);
+                    }
                     throw new LockNotGrantedException("Could not acquire lock because someone else acquired it: ", conditionalCheckFailedException);
                 } catch (ProvisionedThroughputExceededException provisionedThroughputExceededException) {
                     /* Request exceeded maximum allowed provisioned throughput for the table
@@ -597,8 +624,41 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
      */
     public boolean hasLock(final String key, final Optional<String> sortKey) {
         Objects.requireNonNull(sortKey, "Sort Key must not be null (can be Optional.empty())");
-        final LockItem localLock = this.locks.get(key + sortKey.orElse(""));
+        final LockItem localLock = this.locks.get(LockItem.uniqueIdentifier(key, sortKey));
         return localLock != null && !localLock.isExpired();
+    }
+
+    private boolean observedLockIsExpired(final LockItem lockFromDynamoDB) {
+        final String id = lockFromDynamoDB.getUniqueIdentifier();
+        final LockObservation cachedLock = notMyLocks.get(id);
+        if (cachedLock != null && cachedLock.isSameRecordVersion(lockFromDynamoDB)) {
+            return cachedLock.isExpired();
+        }
+
+        if (this.notMyLocks.size() >= this.maxLockObservationCacheSize) {
+            evictNotMyLocks();
+        }
+        this.notMyLocks.put(id, new LockObservation(lockFromDynamoDB));
+        return false;
+    }
+
+    private void evictNotMyLocks() {
+        final long now = LockClientUtils.INSTANCE.millisecondTime();
+        for (Entry<String, LockObservation> entry : this.notMyLocks.entrySet()) {
+            final LockObservation observation = entry.getValue();
+            if (observation.isOlderThan(now, observation.leaseDurationInMilliseconds * 2)) {
+                this.notMyLocks.remove(entry.getKey(), observation);
+            }
+        }
+
+        int remainingToRemove = this.notMyLocks.size() - this.maxLockObservationCacheSize + 1;
+        final Iterator<Entry<String, LockObservation>> iterator = this.notMyLocks.entrySet().iterator();
+        while (remainingToRemove > 0 && iterator.hasNext()) {
+            final Entry<String, LockObservation> entry = iterator.next();
+            if (this.notMyLocks.remove(entry.getKey(), entry.getValue())) {
+                remainingToRemove--;
+            }
+        }
     }
 
     private LockItem upsertAndMonitorExpiredLock(AcquireLockOptions options, String key, Optional<String> sortKey, boolean deleteLockOnRelease,
@@ -623,7 +683,9 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
             if (sortKeyName.isPresent()) {
                 item.remove(sortKeyName.get());
             }
-            final String updateExpression = getUpdateExpressionAndUpdateNameValueMaps(item, expressionAttributeNames, expressionAttributeValues);
+            expressionAttributeNames.put(IS_RELEASED_PATH_EXPRESSION_VARIABLE, IS_RELEASED);
+            final String updateExpression = getUpdateExpressionAndUpdateNameValueMaps(item, expressionAttributeNames, expressionAttributeValues)
+                    + REMOVE_IS_RELEASED_UPDATE_EXPRESSION;
 
             final UpdateItemRequest updateItemRequest = UpdateItemRequest.builder().tableName(tableName).key(getItemKeys(existingLock.get()))
                     .updateExpression(updateExpression).expressionAttributeNames(expressionAttributeNames)
@@ -708,6 +770,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
                 new LockItem(this, key, sortKey, newLockData, deleteLockOnRelease, this.ownerName, this.leaseDurationInMilliseconds, lastUpdatedTime,
                         recordVersionNumber, !IS_RELEASED_INDICATOR, sessionMonitor, options.getAdditionalAttributes());
         this.locks.put(lockItem.getUniqueIdentifier(), lockItem);
+        this.notMyLocks.remove(lockItem.getUniqueIdentifier());
         this.tryAddSessionMonitor(lockItem.getUniqueIdentifier(), lockItem);
         return lockItem;
     }
@@ -776,6 +839,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
             new LockItem(this, key, sortKey, newLockData, deleteLockOnRelease, this.ownerName, this.leaseDurationInMilliseconds, lastUpdatedTime,
                 recordVersionNumber, false, sessionMonitor, options.getAdditionalAttributes());
         this.locks.put(lockItem.getUniqueIdentifier(), lockItem);
+        this.notMyLocks.remove(lockItem.getUniqueIdentifier());
         this.tryAddSessionMonitor(lockItem.getUniqueIdentifier(), lockItem);
         return lockItem;
     }
@@ -815,8 +879,9 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
 
     /**
      * Attempts to acquire lock. If successful, returns the lock. Otherwise,
-     * returns Optional.empty(). For more details on behavior, please see
-     * {@code acquireLock}.
+     * returns Optional.empty(). This includes cases where {@code acquireLock}
+     * would throw {@code LockNotGrantedException} or {@code LockCurrentlyUnavailableException}.
+     * For more details on behavior, please see {@code acquireLock}.
      *
      * @param options The options to use when acquiring the lock.
      * @return the lock if successful.
@@ -825,6 +890,8 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
     public Optional<LockItem> tryAcquireLock(final AcquireLockOptions options) throws InterruptedException {
         try {
             return Optional.of(this.acquireLock(options));
+        } catch (final LockCurrentlyUnavailableException x) {
+            return Optional.empty();
         } catch (final LockNotGrantedException x) {
             return Optional.empty();
         }
@@ -971,7 +1038,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
      */
     public Optional<LockItem> getLock(final String key, final Optional<String> sortKey) {
         Objects.requireNonNull(sortKey, "Sort Key must not be null (can be Optional.empty())");
-        final LockItem localLock = this.locks.get(key + sortKey.orElse(""));
+        final LockItem localLock = this.locks.get(LockItem.uniqueIdentifier(key, sortKey));
         if (localLock != null) {
             return Optional.of(localLock);
         }

--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientOptions.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientOptions.java
@@ -38,6 +38,7 @@ public class AmazonDynamoDBLockClientOptions {
     protected static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;
     protected static final Boolean DEFAULT_CREATE_HEARTBEAT_BACKGROUND_THREAD = true;
     protected static final Boolean DEFAULT_HOLD_LOCK_ON_SERVICE_UNAVAILABLE = false;
+    protected static final Integer DEFAULT_MAX_LOCK_OBSERVATION_CACHE_SIZE = 10000;
 
     private final DynamoDbClient dynamoDBClient;
     private final String tableName;
@@ -50,6 +51,7 @@ public class AmazonDynamoDBLockClientOptions {
     private final Boolean createHeartbeatBackgroundThread;
     private final Function<String, ThreadFactory> namedThreadCreator;
     private final Boolean holdLockOnServiceUnavailable;
+    private final Integer maxLockObservationCacheSize;
 
 
     /**
@@ -67,6 +69,7 @@ public class AmazonDynamoDBLockClientOptions {
         private TimeUnit timeUnit;
         private Boolean createHeartbeatBackgroundThread;
         private Boolean holdLockOnServiceUnavailable;
+        private Integer maxLockObservationCacheSize;
         private Function<String, ThreadFactory> namedThreadCreator;
 
         AmazonDynamoDBLockClientOptionsBuilder(final DynamoDbClient dynamoDBClient, final String tableName) {
@@ -101,6 +104,7 @@ public class AmazonDynamoDBLockClientOptions {
             this.ownerName = ownerName == null ? generateOwnerNameFromLocalhost() : ownerName;
             this.namedThreadCreator = namedThreadCreator == null ? namedThreadCreator() : namedThreadCreator;
             this.holdLockOnServiceUnavailable = DEFAULT_HOLD_LOCK_ON_SERVICE_UNAVAILABLE;
+            this.maxLockObservationCacheSize = DEFAULT_MAX_LOCK_OBSERVATION_CACHE_SIZE;
         }
 
         AmazonDynamoDBLockClientOptionsBuilder(final DynamoDbClient dynamoDBClient, final String tableName, final String ownerName) {
@@ -198,6 +202,18 @@ public class AmazonDynamoDBLockClientOptions {
         }
 
         /**
+         * @param maxLockObservationCacheSize Maximum number of lock observations to keep for shouldSkipBlockingWait stale lock detection.
+         *                                    This is an approximate maximum under concurrent access, and this value must be greater than zero.
+         *                                    If an observation is evicted, a skip-blocking-wait caller must observe the same record version
+         *                                    number again before it can acquire the stale lock.
+         * @return a reference to this builder for fluent method chaining
+         */
+        public AmazonDynamoDBLockClientOptionsBuilder withMaxLockObservationCacheSize(final Integer maxLockObservationCacheSize) {
+            this.maxLockObservationCacheSize = maxLockObservationCacheSize;
+            return this;
+        }
+
+        /**
          * Builds an AmazonDynamoDBLockClientOptions. If required parametes are
          * not set, will throw an IllegalArgumentsException.
          *
@@ -207,8 +223,13 @@ public class AmazonDynamoDBLockClientOptions {
         public AmazonDynamoDBLockClientOptions build() {
             Objects.requireNonNull(this.tableName, "Table Name must not be null");
             Objects.requireNonNull(this.ownerName, "Owner Name must not be null");
+            Objects.requireNonNull(this.maxLockObservationCacheSize, "Maximum lock observation cache size must not be null");
+            if (this.maxLockObservationCacheSize <= 0) {
+                throw new IllegalArgumentException("Maximum lock observation cache size must be greater than zero");
+            }
             return new AmazonDynamoDBLockClientOptions(this.dynamoDBClient, this.tableName, this.partitionKeyName, this.sortKeyName, this.ownerName, this.leaseDuration,
-                this.heartbeatPeriod, this.timeUnit, this.createHeartbeatBackgroundThread, this.namedThreadCreator, this.holdLockOnServiceUnavailable);
+                this.heartbeatPeriod, this.timeUnit, this.createHeartbeatBackgroundThread, this.namedThreadCreator, this.holdLockOnServiceUnavailable,
+                this.maxLockObservationCacheSize);
         }
 
         @Override
@@ -216,7 +237,8 @@ public class AmazonDynamoDBLockClientOptions {
             return "AmazonDynamoDBLockClientOptionsBuilder(dynamoDBClient=" + this.dynamoDBClient + ", tableName=" + this.tableName + ", partitionKeyName=" + this.partitionKeyName
                 + ", sortKeyName=" + this.sortKeyName + ", ownerName=" + this.ownerName + ", leaseDuration=" + this.leaseDuration + ", heartbeatPeriod=" + this.heartbeatPeriod
                 + ", timeUnit=" + this.timeUnit + ", createHeartbeatBackgroundThread=" + this.createHeartbeatBackgroundThread
-                + ", holdLockOnServiceUnavailable=" + this.holdLockOnServiceUnavailable + ")";
+                + ", holdLockOnServiceUnavailable=" + this.holdLockOnServiceUnavailable + ", maxLockObservationCacheSize="
+                + this.maxLockObservationCacheSize + ")";
         }
     }
 
@@ -235,7 +257,7 @@ public class AmazonDynamoDBLockClientOptions {
 
     private AmazonDynamoDBLockClientOptions(final DynamoDbClient dynamoDBClient, final String tableName, final String partitionKeyName, final Optional<String> sortKeyName,
         final String ownerName, final Long leaseDuration, final Long heartbeatPeriod, final TimeUnit timeUnit, final Boolean createHeartbeatBackgroundThread,
-        final Function<String, ThreadFactory> namedThreadCreator, final Boolean holdLockOnServiceUnavailable) {
+        final Function<String, ThreadFactory> namedThreadCreator, final Boolean holdLockOnServiceUnavailable, final Integer maxLockObservationCacheSize) {
         this.dynamoDBClient = dynamoDBClient;
         this.tableName = tableName;
         this.partitionKeyName = partitionKeyName;
@@ -247,6 +269,7 @@ public class AmazonDynamoDBLockClientOptions {
         this.createHeartbeatBackgroundThread = createHeartbeatBackgroundThread;
         this.namedThreadCreator = namedThreadCreator;
         this.holdLockOnServiceUnavailable = holdLockOnServiceUnavailable;
+        this.maxLockObservationCacheSize = maxLockObservationCacheSize;
     }
 
     /**
@@ -330,5 +353,12 @@ public class AmazonDynamoDBLockClientOptions {
      */
     Boolean getHoldLockOnServiceUnavailable() {
         return this.holdLockOnServiceUnavailable;
+    }
+
+    /**
+     * @return Approximate maximum number of lock observations to keep for shouldSkipBlockingWait stale lock detection.
+     */
+    Integer getMaxLockObservationCacheSize() {
+        return this.maxLockObservationCacheSize;
     }
 }

--- a/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
@@ -319,7 +319,12 @@ public class LockItem implements Closeable {
      * Returns the unique identifier for the lock so it can be stored in a HashMap under that key
      */
     String getUniqueIdentifier() {
-        return this.partitionKey + this.sortKey.orElse("");
+        return uniqueIdentifier(this.partitionKey, this.sortKey);
+    }
+
+    static String uniqueIdentifier(final String partitionKey, final Optional<String> sortKey) {
+        return "pk:" + partitionKey.length() + ":" + partitionKey
+            + "|sk:" + sortKey.map(sk -> sk.length() + ":" + sk).orElse("null");
     }
 
     /**

--- a/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientOptionsTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientOptionsTest.java
@@ -66,4 +66,27 @@ public class AmazonDynamoDBLockClientOptionsTest {
         LockItem lock = client.acquireLock(AcquireLockOptions.builder("asdf").build());
         assertEquals(uuid.toString(), lock.getOwnerName());
     }
+
+    @Test
+    public void build_whenMaxLockObservationCacheSizeNotSet_usesDefault() {
+        AmazonDynamoDBLockClientOptions options = AmazonDynamoDBLockClientOptions.builder(dynamodb, "table").build();
+
+        assertEquals(AmazonDynamoDBLockClientOptions.DEFAULT_MAX_LOCK_OBSERVATION_CACHE_SIZE, options.getMaxLockObservationCacheSize());
+    }
+
+    @Test
+    public void build_whenMaxLockObservationCacheSizeSet_usesValue() {
+        AmazonDynamoDBLockClientOptions options = AmazonDynamoDBLockClientOptions.builder(dynamodb, "table")
+            .withMaxLockObservationCacheSize(123)
+            .build();
+
+        assertEquals(Integer.valueOf(123), options.getMaxLockObservationCacheSize());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void build_whenMaxLockObservationCacheSizeIsZero_throwsIllegalArgumentException() {
+        AmazonDynamoDBLockClientOptions.builder(dynamodb, "table")
+            .withMaxLockObservationCacheSize(0)
+            .build();
+    }
 }

--- a/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
@@ -51,6 +51,8 @@ import com.amazonaws.services.dynamodbv2.util.LockClientUtils;
 
 import static com.amazonaws.services.dynamodbv2.AmazonDynamoDBLockClient
         .PK_EXISTS_AND_RVN_IS_THE_SAME_AND_IS_RELEASED_CONDITION;
+import static com.amazonaws.services.dynamodbv2.AmazonDynamoDBLockClient.IS_RELEASED_PATH_EXPRESSION_VARIABLE;
+import static com.amazonaws.services.dynamodbv2.AmazonDynamoDBLockClient.REMOVE_IS_RELEASED_UPDATE_EXPRESSION;
 import static com.amazonaws.services.dynamodbv2.AmazonDynamoDBLockClient.RVN_VALUE_EXPRESSION_VARIABLE;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -447,6 +449,159 @@ public class AmazonDynamoDBLockClientTest {
             .withDeleteLockOnRelease(false).build();
         client.acquireLock(acquireLockOptions);
     }
+
+    @Test
+    public void tryAcquireLock_whenLockAlreadyExistsAndIsNotReleased_andSkipBlockingWait_returnsEmpty()
+        throws InterruptedException {
+        UUID uuid = setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        Map<String, AttributeValue> item = new HashMap<>(5);
+        item.put("customer", AttributeValue.builder().s("customer1").build());
+        item.put("ownerName", AttributeValue.builder().s("foobar").build());
+        item.put("recordVersionNumber", AttributeValue.builder().s(uuid.toString()).build());
+        item.put("leaseDuration", AttributeValue.builder().s("100000").build());
+        when(dynamodb.getItem(Mockito.<GetItemRequest>any()))
+            .thenReturn(GetItemResponse.builder().item(item).build());
+        AcquireLockOptions acquireLockOptions = AcquireLockOptions.builder("customer1")
+            .withShouldSkipBlockingWait(true)
+            .withDeleteLockOnRelease(false).build();
+
+        Optional<LockItem> lockItem = client.tryAcquireLock(acquireLockOptions);
+
+        assertFalse(lockItem.isPresent());
+    }
+
+    @Test(expected = LockCurrentlyUnavailableException.class)
+    public void acquireLock_whenExpiredCachedLockIsConcurrentlyAcquired_andSkipBlockingWait_throwsUnavailable()
+        throws InterruptedException {
+        UUID uuid = setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        Map<String, AttributeValue> item = new HashMap<>(5);
+        item.put("customer", AttributeValue.builder().s("customer1").build());
+        item.put("ownerName", AttributeValue.builder().s("foobar").build());
+        item.put("recordVersionNumber", AttributeValue.builder().s(uuid.toString()).build());
+        item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        when(dynamodb.getItem(Mockito.<GetItemRequest>any()))
+            .thenReturn(GetItemResponse.builder().item(item).build())
+            .thenReturn(GetItemResponse.builder().item(item).build());
+        doThrow(ConditionalCheckFailedException.builder().message("lost race").build())
+            .when(dynamodb).putItem(Mockito.<PutItemRequest>any());
+        AcquireLockOptions acquireLockOptions = AcquireLockOptions.builder("customer1")
+            .withShouldSkipBlockingWait(true)
+            .withDeleteLockOnRelease(false).build();
+
+        try {
+            client.acquireLock(acquireLockOptions);
+        } catch (LockCurrentlyUnavailableException e) {
+            // This is expected on the first observation, before the cached item expires.
+        }
+
+        Thread.sleep(2);
+        client.acquireLock(acquireLockOptions);
+    }
+
+    @Test(expected = LockCurrentlyUnavailableException.class)
+    public void acquireLock_whenExpiredCachedLockIsConcurrentlyUpdated_andSkipBlockingWait_throwsUnavailable()
+        throws InterruptedException {
+        AmazonDynamoDBLockClient client = getLockClient();
+        Map<String, AttributeValue> item = new HashMap<>(5);
+        item.put("customer", AttributeValue.builder().s("customer1").build());
+        item.put("ownerName", AttributeValue.builder().s("foobar").build());
+        item.put("recordVersionNumber", AttributeValue.builder().s("rvn-1").build());
+        item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        when(dynamodb.getItem(Mockito.<GetItemRequest>any()))
+            .thenReturn(GetItemResponse.builder().item(item).build())
+            .thenReturn(GetItemResponse.builder().item(item).build());
+        doThrow(ConditionalCheckFailedException.builder().message("lost race").build())
+            .when(dynamodb).updateItem(Mockito.<UpdateItemRequest>any());
+        AcquireLockOptions acquireLockOptions = AcquireLockOptions.builder("customer1")
+            .withShouldSkipBlockingWait(true)
+            .withUpdateExistingLockRecord(true)
+            .withDeleteLockOnRelease(false).build();
+
+        try {
+            client.acquireLock(acquireLockOptions);
+        } catch (LockCurrentlyUnavailableException e) {
+            // This is expected on the first observation, before the cached item expires.
+        }
+
+        Thread.sleep(2);
+        client.acquireLock(acquireLockOptions);
+    }
+
+    @Test
+    public void acquireLock_whenExpiredCachedLockIsUpdated_andUpdateExistingLockRecord_removesIsReleased()
+        throws InterruptedException {
+        AmazonDynamoDBLockClient client = getLockClient();
+        Map<String, AttributeValue> item = new HashMap<>(5);
+        item.put("customer", AttributeValue.builder().s("customer1").build());
+        item.put("ownerName", AttributeValue.builder().s("foobar").build());
+        item.put("recordVersionNumber", AttributeValue.builder().s("rvn-1").build());
+        item.put("leaseDuration", AttributeValue.builder().s("1").build());
+        when(dynamodb.getItem(Mockito.<GetItemRequest>any()))
+            .thenReturn(GetItemResponse.builder().item(item).build())
+            .thenReturn(GetItemResponse.builder().item(item).build());
+        AcquireLockOptions acquireLockOptions = AcquireLockOptions.builder("customer1")
+            .withShouldSkipBlockingWait(true)
+            .withUpdateExistingLockRecord(true)
+            .withDeleteLockOnRelease(false).build();
+
+        try {
+            client.acquireLock(acquireLockOptions);
+        } catch (LockCurrentlyUnavailableException e) {
+            // This is expected on the first observation, before the cached item expires.
+        }
+
+        Thread.sleep(2);
+        client.acquireLock(acquireLockOptions);
+
+        ArgumentCaptor<UpdateItemRequest> updateItemCaptor = ArgumentCaptor.forClass(UpdateItemRequest.class);
+        verify(dynamodb).updateItem(updateItemCaptor.capture());
+        UpdateItemRequest updateItemRequest = updateItemCaptor.getValue();
+        assertTrue(updateItemRequest.updateExpression().contains(REMOVE_IS_RELEASED_UPDATE_EXPRESSION.trim()));
+        assertEquals("isReleased", updateItemRequest.expressionAttributeNames().get(IS_RELEASED_PATH_EXPRESSION_VARIABLE));
+    }
+
+    @Test
+    public void acquireLock_whenRecordVersionChangesAfterCachedObservation_andSkipBlockingWait_observesNewVersionBeforeAcquiring()
+        throws InterruptedException {
+        AmazonDynamoDBLockClient client = getLockClient();
+        Map<String, AttributeValue> firstItem = new HashMap<>(5);
+        firstItem.put("customer", AttributeValue.builder().s("customer1").build());
+        firstItem.put("ownerName", AttributeValue.builder().s("foobar").build());
+        firstItem.put("recordVersionNumber", AttributeValue.builder().s("rvn-1").build());
+        firstItem.put("leaseDuration", AttributeValue.builder().s("1").build());
+        Map<String, AttributeValue> secondItem = new HashMap<>(5);
+        secondItem.put("customer", AttributeValue.builder().s("customer1").build());
+        secondItem.put("ownerName", AttributeValue.builder().s("foobar").build());
+        secondItem.put("recordVersionNumber", AttributeValue.builder().s("rvn-2").build());
+        secondItem.put("leaseDuration", AttributeValue.builder().s("1").build());
+        when(dynamodb.getItem(Mockito.<GetItemRequest>any()))
+            .thenReturn(GetItemResponse.builder().item(firstItem).build())
+            .thenReturn(GetItemResponse.builder().item(secondItem).build())
+            .thenReturn(GetItemResponse.builder().item(secondItem).build());
+        AcquireLockOptions acquireLockOptions = AcquireLockOptions.builder("customer1")
+            .withShouldSkipBlockingWait(true)
+            .withDeleteLockOnRelease(false).build();
+
+        try {
+            client.acquireLock(acquireLockOptions);
+        } catch (LockCurrentlyUnavailableException e) {
+            // This is expected on the first observation.
+        }
+
+        Thread.sleep(2);
+        try {
+            client.acquireLock(acquireLockOptions);
+        } catch (LockCurrentlyUnavailableException e) {
+            // The changed record version number should reset the stale observation.
+        }
+
+        Thread.sleep(2);
+        LockItem lockItem = client.acquireLock(acquireLockOptions);
+        Assert.assertNotNull("Failed to get lock item after observing the same record version long enough", lockItem);
+    }
+
     /*
      * Test case for the scenario, where the lock is being held by the first owner and the lock duration has not past
      * the lease duration. In this case, We should expect a LockAlreadyOwnedException when shouldSkipBlockingWait is set.

--- a/src/test/java/com/amazonaws/services/dynamodbv2/LockItemTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/LockItemTest.java
@@ -181,6 +181,14 @@ public class LockItemTest {
         assertEquals(2000, lockItem.getLookupTime());
     }
 
+    @Test
+    public void uniqueIdentifier_whenPartitionAndSortKeyCouldConcatenateSame_returnsDifferentValues() {
+        assertFalse(LockItem.uniqueIdentifier("ab", Optional.of("c"))
+            .equals(LockItem.uniqueIdentifier("a", Optional.of("bc"))));
+        assertFalse(LockItem.uniqueIdentifier("abc", Optional.empty())
+            .equals(LockItem.uniqueIdentifier("ab", Optional.of("c"))));
+    }
+
     static LockItem createLockItem(AmazonDynamoDBLockClient lockClient) {
         return new LockItem(lockClient, "partitionKey",
             Optional.of("sortKey"),


### PR DESCRIPTION
## Why

`shouldSkipBlockingWait(true)` had several edge cases that could prevent non-blocking callers from making progress on dead locks or could leave inconsistent local/DynamoDB lock state.

Concrete bugs fixed:

- A caller repeatedly using skip-wait could fail to acquire a dead lock unless the client retained and used the earlier RVN observation correctly.
- `tryAcquireLock` could leak `LockCurrentlyUnavailableException` instead of returning `Optional.empty()` for skip-wait contention.
- Conditional write races in skip-wait mode could enter the normal blocking retry loop instead of failing fast.
- Local lock/cache IDs could collide for distinct partition/sort-key pairs because they were built by simple string concatenation.
- Expired-lock takeovers through `UpdateItem` could leave a stale `isReleased` marker on the newly-owned DynamoDB row.

## What

- Replaces cached non-owned `LockItem` instances with lightweight `LockObservation` entries containing only the observed RVN, lookup time, and lease duration.
  - A freshly-read `LockItem` starts its local expiration clock at read time, so it cannot prove that an unchanged RVN is already stale.
  - The observation keeps the earlier timestamp needed for stale detection without retaining lock data, additional attributes, session monitor state, or a full `LockItem` for locks this client does not own.
- Uses collision-safe local identifiers for partition/sort-key locks.
- Makes `tryAcquireLock` return `Optional.empty()` for skip-wait contention.
- Fails fast on conditional write races when skip-wait is enabled.
- Clears cached observations after successful acquisition.
- Adds a configurable approximate max size for the observation cache.
- Removes stale `isReleased` markers when taking over expired locks via `UpdateItem`.
- Documents the narrow skip-wait semantics and cache caveats.
- Adds regression coverage for RVN changes, skip-wait races, update-existing takeovers, cache sizing, and unique identifier collisions.

## Verification

Using Java 17, the full unit suite passed with PowerMock module opens:

```bash
mvn -q clean test -Dlog4j2.disableJmx=true -DargLine='--add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.util.concurrent=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED'
```

Also reran after the latest comment-only cleanup:

```bash
mvn -q -DskipTests compile
git diff --check
```


---
**Update Jun 7, 23:56:** Clarified the public acquire exception contract.
- README and Javadocs now state that skip-wait `acquireLock` can throw `LockCurrentlyUnavailableException`.
- `tryAcquireLock` docs now state that both `LockCurrentlyUnavailableException` and `LockNotGrantedException` become `Optional.empty()`.
- Validation for this docs-only update: `git diff --check`.
