### PR TITLE
Fix LockItem and SessionMonitor correctness bugs

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
@@ -20,7 +20,6 @@ import com.amazonaws.services.dynamodbv2.util.LockClientUtils;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -193,7 +192,14 @@ public class LockItem implements Closeable {
     @Override
     public String toString() {
         String dataString = this.data
-            .map(byteBuffer -> new String(byteBuffer.array(), StandardCharsets.UTF_8))
+            .map(byteBuffer -> {
+                /* Copy via a read-only duplicate: the buffer may be read-only (no array() access) and may have a non-zero
+                 * position/offset, so reading the backing array directly would fail or return the wrong bytes. */
+                final ByteBuffer readOnlyBuffer = byteBuffer.asReadOnlyBuffer();
+                final byte[] bytes = new byte[readOnlyBuffer.remaining()];
+                readOnlyBuffer.get(bytes);
+                return new String(bytes, StandardCharsets.UTF_8);
+            })
             .orElse("");
         return String
             .format("LockItem{Partition Key=%s, Sort Key=%s, Owner Name=%s, Lookup Time=%d, Lease Duration=%d, "
@@ -203,15 +209,15 @@ public class LockItem implements Closeable {
     }
 
     /**
-     * Hash code of just the (key, ownerName) as that is what uniquely identifies this lock.
+     * Hash code of just the (key, sortKey, ownerName) as that is what uniquely identifies this lock.
      */
     @Override
     public int hashCode() {
-        return Arrays.hashCode(Arrays.asList(this.partitionKey, this.ownerName).toArray());
+        return Objects.hash(this.partitionKey, this.sortKey, this.ownerName);
     }
 
     /**
-     * Returns if two locks have the same (key, ownerName)
+     * Returns if two locks have the same (key, sortKey, ownerName)
      */
     @Override
     public boolean equals(final Object other) {
@@ -220,8 +226,9 @@ public class LockItem implements Closeable {
         }
 
         final LockItem otherLockItem = (LockItem) other;
-        /* key and ownerName should never be null due to a preconditions check */
-        return this.partitionKey.equals(otherLockItem.getPartitionKey()) && this.ownerName.equals(otherLockItem.getOwnerName());
+        /* key, sortKey and ownerName should never be null due to a preconditions check */
+        return this.partitionKey.equals(otherLockItem.getPartitionKey()) && this.sortKey.equals(otherLockItem.getSortKey())
+            && this.ownerName.equals(otherLockItem.getOwnerName());
     }
 
     /**
@@ -261,8 +268,8 @@ public class LockItem implements Closeable {
     /**
      * <p>
      * Ensures that this owner has the lock for a specified period of time. If the lock will expire in less than the amount of
-     * time passed in, then this method will do nothing. Otherwise, it will set the {@code leaseDuration} to that value and send a
-     * heartbeat, such that the lock will expire no sooner than after {@code leaseDuration} elapses.
+     * time passed in, then this method will set the {@code leaseDuration} to that value and send a heartbeat, such that the lock
+     * will expire no sooner than after {@code leaseDuration} elapses. Otherwise, this method will do nothing.
      * </p>
      * <p>
      * This method is not required if using heartbeats, because the client could simply call {@code isExpired} before every
@@ -293,7 +300,10 @@ public class LockItem implements Closeable {
      * client.
      */
     void updateRecordVersionNumber(final String recordVersionNumber, final long lastUpdateOfLock, final long leaseDurationToEnsureInMilliseconds) {
-        this.recordVersionNumber.replace(0, recordVersionNumber.length(), recordVersionNumber);
+        /* Clear before appending: replace(0, newValue.length(), newValue) is wrong when the new value is shorter than the
+         * old one (e.g. clearing the RVN with ""), as it leaves the old value's trailing characters in place. */
+        this.recordVersionNumber.setLength(0);
+        this.recordVersionNumber.append(recordVersionNumber);
         this.lookupTime.set(lastUpdateOfLock);
         this.leaseDuration.set(leaseDurationToEnsureInMilliseconds);
     }

--- a/src/main/java/com/amazonaws/services/dynamodbv2/SessionMonitor.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/SessionMonitor.java
@@ -41,7 +41,7 @@ final class SessionMonitor {
      */
     public SessionMonitor(final long safeTimeWithoutHeartbeatMillis, final Optional<Runnable> callback) {
         this.safeTimeWithoutHeartbeatMillis = safeTimeWithoutHeartbeatMillis;
-        this.callback = callback;
+        this.callback = callback == null ? Optional.empty() : callback;
     }
 
     /**
@@ -85,13 +85,13 @@ final class SessionMonitor {
     }
 
     /**
-     * Returns whether or not the callback is non-null
+     * Returns whether or not a callback was provided
      *
      * @return <code>true</code> if this SessionMonitor has a callback,
      * otherwise <code>false</code>
      */
     public boolean hasCallback() {
-        return this.callback != null;
+        return this.callback.isPresent();
     }
 
     /**

--- a/src/test/java/com/amazonaws/services/dynamodbv2/LockItemTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/LockItemTest.java
@@ -94,6 +94,50 @@ public class LockItemTest {
     }
 
     @Test
+    public void equals_differentSortKey_returnFalse() {
+        final LockItem differentSortKey = new LockItem(lockClient, "partitionKey",
+            Optional.of("differentSortKey"),
+            Optional.of(ByteBuffer.wrap("data".getBytes())),
+            false, //delete lock item on close
+            "ownerName",
+            1L, //lease duration
+            1000, //last updated time in milliseconds
+            "recordVersionNumber",
+            false, //released
+            Optional.of(new SessionMonitor(1000, Optional.empty())), //session monitor
+            new HashMap<>());
+        assertFalse(createLockItem(lockClient).equals(differentSortKey));
+        assertFalse(createLockItem(lockClient).hashCode() == differentSortKey.hashCode());
+    }
+
+    @Test
+    public void toString_whenDataBufferIsReadOnly_returnsData() {
+        final LockItem lockItem = new LockItem(lockClient, "partitionKey",
+            Optional.of("sortKey"),
+            Optional.of(ByteBuffer.wrap("data".getBytes()).asReadOnlyBuffer()),
+            false, //delete lock item on close
+            "ownerName",
+            1L, //lease duration
+            1000, //last updated time in milliseconds
+            "recordVersionNumber",
+            false, //released
+            Optional.empty(), //session monitor
+            new HashMap<>());
+        assertTrue(lockItem.toString().contains("Data=data"));
+    }
+
+    @Test
+    public void updateRecordVersionNumber_whenNewValueIsShorter_replacesEntireValue() {
+        final LockItem lockItem = createLockItem(lockClient);
+        lockItem.updateRecordVersionNumber("", 0, 0);
+        assertEquals("", lockItem.getRecordVersionNumber());
+
+        lockItem.updateRecordVersionNumber("short", 0, 0);
+        lockItem.updateRecordVersionNumber("x", 0, 0);
+        assertEquals("x", lockItem.getRecordVersionNumber());
+    }
+
+    @Test
     public void isExpired_whenIsReleasedTrue_returnTrue() {
         assertTrue(new LockItem(lockClient, "partitionKey",
             Optional.of("sortKey"),

--- a/src/test/java/com/amazonaws/services/dynamodbv2/SessionMonitorTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/SessionMonitorTest.java
@@ -61,8 +61,15 @@ public class SessionMonitorTest {
     }
 
     @Test
-    public void hasCallback_whenCallbackNotNull_returnTrue() {
+    public void hasCallback_whenCallbackEmpty_returnFalse() {
         SessionMonitor sut = new SessionMonitor(1000, Optional.empty());
+        assertFalse(sut.hasCallback());
+    }
+
+    @Test
+    public void hasCallback_whenCallbackPresent_returnTrue() {
+        SessionMonitor sut = new SessionMonitor(1000, Optional.of(() -> {
+        }));
         assertTrue(sut.hasCallback());
     }
 }


### PR DESCRIPTION
## Summary

Fixes several independent correctness bugs in `LockItem` and `SessionMonitor`.

### `LockItem.updateRecordVersionNumber` leaves stale characters behind

`StringBuffer.replace(0, newValue.length(), newValue)` only replaces the first `newValue.length()` characters, so any time the new value is shorter than the old one, the old value's trailing characters survive. In particular, `getLock()` clears the record version number with `""` so that callers "cannot accidentally perform updates on this lock" — but `replace(0, 0, "")` is a no-op, so the RVN was never actually cleared. A `releaseLock()` on a `getLock()`-returned item could therefore pass its conditional check (owner + RVN match) and release or delete a lock that was never acquired, defeating the documented safeguard. It only appeared to work because UUID RVNs are all the same length. Fixed by clearing the buffer and appending.

### `LockItem.equals`/`hashCode` ignore the sort key

Lock identity everywhere else in the client is `(partitionKey, sortKey)`, but `equals`/`hashCode` only used `(partitionKey, ownerName)`, so two distinct locks that share a partition key compared equal and collided in user-side sets/maps. The sort key is now included.

### `LockItem.toString()` throws for locks read from DynamoDB

`toString()` called `ByteBuffer.array()`, which throws `ReadOnlyBufferException` for the read-only buffers produced by `SdkBytes.asByteBuffer()` (i.e., any lock item loaded from DynamoDB with data), and also ignores the buffer's position/offset. This included log statements in the heartbeat thread, where the secondary exception masked the original error. The data is now copied through a read-only duplicate.

### `SessionMonitor.hasCallback()` always returns true

The callback field is an `Optional<Runnable>`, so the previous `!= null` check was always true and a session-monitor thread was spawned even when no callback was supplied, contradicting the documented behavior. Now checks `Optional.isPresent()` (and normalizes a literal `null` Optional in the constructor). With this change, no monitor thread is created for callback-less session monitors; `amIAboutToExpire()` continues to work as before.

### `LockItem.ensure()` javadoc inverted

The javadoc described the opposite of the implemented (correct) behavior; the heartbeat is sent when the remaining lease is *shorter* than the requested duration.

## Testing

- `mvn clean test` — 97/97 unit tests pass
- `mvn clean verify -P integration-tests` against DynamoDB Local — 108/108 integration tests pass
- New unit tests cover each fix: sort-key inequality, read-only data buffer in `toString()`, shorter-RVN replacement, and `hasCallback()` semantics for empty/present callbacks. One existing test (`hasCallback_whenCallbackNotNull_returnTrue`) codified the buggy always-true behavior and was updated to the corrected semantics.
