### PR TITLE
Fix lock client lifecycle and heartbeat correctness bugs

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClient.java
@@ -45,10 +45,12 @@ import com.amazonaws.services.dynamodbv2.model.LockNotGrantedException;
 import com.amazonaws.services.dynamodbv2.model.LockTableDoesNotExistException;
 import com.amazonaws.services.dynamodbv2.util.LockClientUtils;
 import software.amazon.awssdk.annotations.ThreadSafe;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -996,6 +998,7 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
             // should not cause existing clients problems, there
             // may be existing clients that depend on the monitor firing if they
             // get exceptions from this method.
+            lockItem.markReleased();
             this.removeKillSessionMonitor(lockItem.getUniqueIdentifier());
         }
         return true;
@@ -1015,13 +1018,16 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
     }
 
     /**
-     * Releases all the locks currently held by the owner specified when creating this lock client
+     * Releases all the locks currently held by the owner specified when creating this lock client. Releasing a lock is
+     * best-effort here: a failure to release one lock (for example, because of a network error) must not prevent the
+     * remaining locks from being released.
      */
     private void releaseAllLocks() {
-        final Map<String, LockItem> locks = new HashMap<>(this.locks);
-        synchronized (locks) {
-            for (final Entry<String, LockItem> lockEntry : locks.entrySet()) {
-                this.releaseLock(lockEntry.getValue()); // TODO catch exceptions and report failure separately
+        for (final LockItem lockItem : new ArrayList<>(this.locks.values())) {
+            try {
+                this.releaseLock(lockItem);
+            } catch (final RuntimeException e) {
+                logger.warn("Failed to release lock " + lockItem.getUniqueIdentifier() + ", continuing to release the remaining locks", e);
             }
         }
     }
@@ -1227,10 +1233,20 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
         final LockItem lockItem = options.getLockItem();
         if (lockItem.isExpired() || !lockItem.getOwnerName().equals(this.ownerName) || lockItem.isReleased()) {
             this.locks.remove(lockItem.getUniqueIdentifier());
+            // The lock is abandoned: also stop its session monitor so it cannot fire later for an acquisition
+            // that this client no longer tracks. By this point the lease has lapsed, so a configured danger-zone
+            // callback (safe time < lease duration) has already had its chance to fire.
+            this.removeKillSessionMonitor(lockItem.getUniqueIdentifier());
             throw new LockNotGrantedException("Cannot send heartbeat because lock is not granted");
         }
 
         synchronized (lockItem) {
+            if (lockItem.isExpired() || !lockItem.getOwnerName().equals(this.ownerName) || lockItem.isReleased()) {
+                this.locks.remove(lockItem.getUniqueIdentifier());
+                this.removeKillSessionMonitor(lockItem.getUniqueIdentifier());
+                throw new LockNotGrantedException("Cannot send heartbeat because lock is not granted");
+            }
+
             //Set up condition for UpdateItem. Basically any changes require:
             //1. I own the lock
             //2. I know the current version number
@@ -1288,10 +1304,12 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
             } catch (final ConditionalCheckFailedException conditionalCheckFailedException) {
                 logger.debug("Someone else acquired the lock, so we will stop heartbeating it", conditionalCheckFailedException);
                 this.locks.remove(lockItem.getUniqueIdentifier());
+                // The lock was stolen, which can only happen after the lease lapsed, so the danger-zone callback has
+                // already had its chance to fire. Stop the monitor so it cannot fire later for this dead acquisition.
+                this.removeKillSessionMonitor(lockItem.getUniqueIdentifier());
                 throw new LockNotGrantedException("Someone else acquired the lock, so we will stop heartbeating it", conditionalCheckFailedException);
             } catch (AwsServiceException awsServiceException) {
-                if (holdLockOnServiceUnavailable
-                        && awsServiceException.awsErrorDetails().sdkHttpResponse().statusCode() == HttpStatusCode.SERVICE_UNAVAILABLE) {
+                if (holdLockOnServiceUnavailable && isServiceUnavailable(awsServiceException)) {
                     // When DynamoDB service is unavailable, other threads may get the same exception and no thread may have the lock.
                     // For systems which should always hold a lock on an item and it is okay for multiple threads to hold the lock,
                     // the lookUpTime of local state can be updated to make it believe that it still has the lock.
@@ -1302,6 +1320,20 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
                 }
             }
         }
+    }
+
+    private static boolean isServiceUnavailable(final AwsServiceException awsServiceException) {
+        if (awsServiceException.statusCode() == HttpStatusCode.SERVICE_UNAVAILABLE) {
+            return true;
+        }
+
+        final AwsErrorDetails awsErrorDetails = awsServiceException.awsErrorDetails();
+        if (awsErrorDetails == null) {
+            return false;
+        }
+
+        final SdkHttpResponse sdkHttpResponse = awsErrorDetails.sdkHttpResponse();
+        return sdkHttpResponse != null && sdkHttpResponse.statusCode() == HttpStatusCode.SERVICE_UNAVAILABLE;
     }
 
     /**
@@ -1347,16 +1379,20 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
      */
     @Override
     public void close() throws IOException {
-        // release the locks before interrupting the heartbeat thread to avoid partially updated/stale locks
-        this.releaseAllLocks();
-        if (this.backgroundThread.isPresent()) {
-            this.shuttingDown = true;
-            this.backgroundThread.get().interrupt();
-            try {
-                this.backgroundThread.get().join();
-            } catch (final InterruptedException e) {
-                logger.warn("Caught InterruptedException waiting for background thread to exit, interrupting current thread");
-                Thread.currentThread().interrupt();
+        try {
+            // release the locks before interrupting the heartbeat thread to avoid partially updated/stale locks
+            this.releaseAllLocks();
+        } finally {
+            // always stop the heartbeat thread, even if releasing a lock failed unexpectedly
+            if (this.backgroundThread.isPresent()) {
+                this.shuttingDown = true;
+                this.backgroundThread.get().interrupt();
+                try {
+                    this.backgroundThread.get().join();
+                } catch (final InterruptedException e) {
+                    logger.warn("Caught InterruptedException waiting for background thread to exit, interrupting current thread");
+                    Thread.currentThread().interrupt();
+                }
             }
         }
     }
@@ -1395,6 +1431,9 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
     }
 
     private void tryAddSessionMonitor(final String lockName, final LockItem lock) {
+        // Kill any monitor left over from a previous acquisition of this lock, so it cannot fire for an
+        // acquisition that no longer exists and is not orphaned by the put below.
+        this.removeKillSessionMonitor(lockName);
         if (lock.hasSessionMonitor() && lock.hasCallback()) {
             final Thread monitorThread = lockSessionMonitorChecker(lockName, lock);
             monitorThread.setDaemon(true);
@@ -1404,8 +1443,8 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
     }
 
     private void removeKillSessionMonitor(final String monitorName) {
-        if (this.sessionMonitors.containsKey(monitorName)) {
-            final Thread monitor = this.sessionMonitors.remove(monitorName);
+        final Thread monitor = this.sessionMonitors.remove(monitorName);
+        if (monitor != null) {
             monitor.interrupt();
             try {
                 monitor.join();
@@ -1447,7 +1486,9 @@ public class AmazonDynamoDBLockClient implements Runnable, Closeable {
                         Thread.sleep(millisUntilDangerZone);
                     } else {
                         lock.runSessionMonitor();
-                        sessionMonitors.remove(monitorName);
+                        // Only remove this thread's own entry: a newer acquisition may have registered its own monitor
+                        // under the same name, and that entry must not be removed.
+                        sessionMonitors.remove(monitorName, Thread.currentThread());
                         return;
                     }
                 } catch (final InterruptedException e) {

--- a/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/LockItem.java
@@ -41,7 +41,11 @@ public class LockItem implements Closeable {
     private Optional<ByteBuffer> data;
     private final String ownerName;
     private final boolean deleteLockItemOnClose;
-    private final boolean isReleased;
+
+    // This can change when a locally-held lock is released. It is volatile so other threads holding the same
+    // LockItem reference (for example, a manual heartbeat or ensure caller) observe that release without requiring
+    // every read path to synchronize on the LockItem monitor.
+    private volatile boolean isReleased;
     private final AtomicLong lookupTime;
     private final StringBuffer recordVersionNumber;
     private final AtomicLong leaseDuration;
@@ -243,6 +247,10 @@ public class LockItem implements Closeable {
      */
     boolean isReleased() {
         return this.isReleased;
+    }
+
+    void markReleased() {
+        this.isReleased = true;
     }
 
     /**

--- a/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
+++ b/src/test/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBLockClientTest.java
@@ -26,7 +26,9 @@ import static org.powermock.api.mockito.PowerMockito.when;
 import java.net.Inet4Address;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -65,12 +67,14 @@ import com.amazonaws.services.dynamodbv2.model.LockNotGrantedException;
 import com.amazonaws.services.dynamodbv2.model.LockTableDoesNotExistException;
 import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.core.exception.SdkServiceException;
 import software.amazon.awssdk.http.HttpStatusCode;
 import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableRequest;
 import software.amazon.awssdk.services.dynamodb.model.DescribeTableResponse;
 import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
@@ -765,6 +769,152 @@ public class AmazonDynamoDBLockClientTest {
         assertTrue(lockItemSpy.getLookupTime() > lastUpdatedTimeInMilliseconds);
         verify(lockItemSpy, times(1)).updateLookUpTime(anyLong());
         verify(lockItemSpy, times(0)).updateRecordVersionNumber(anyString(), anyLong(), anyLong());
+    }
+
+    @Test
+    public void sendHeartbeat_whenServiceExceptionHasNoErrorDetails_andHoldLockOnServiceUnavailableTrue_thenThrowsOriginalException() {
+        AwsServiceException serviceException = AwsServiceException.builder().message("Service exception without error details").build();
+        when(dynamodb.updateItem(Mockito.<UpdateItemRequest>any())).thenThrow(serviceException);
+
+        UUID uuid = setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = new AmazonDynamoDBLockClient(getLockClientBuilder(null)
+                .withHoldLockOnServiceUnavailable(true).build());
+
+        long lastUpdatedTimeInMilliseconds = LockClientUtils.INSTANCE.millisecondTime();
+        LockItem item = new LockItem(client, "a", Optional.empty(), Optional.of(ByteBuffer.wrap("data".getBytes())),
+                false, uuid.toString(), 10000L, lastUpdatedTimeInMilliseconds,
+                "rvn", false, Optional.empty(), null);
+
+        AwsServiceException thrownException = null;
+        try {
+            client.sendHeartbeat(SendHeartbeatOptions.builder(item).build());
+            fail("expected AwsServiceException");
+        } catch (AwsServiceException e) {
+            thrownException = e;
+        }
+
+        assertEquals(serviceException, thrownException);
+        assertEquals(lastUpdatedTimeInMilliseconds, item.getLookupTime());
+    }
+
+    @Test
+    public void sendHeartbeat_afterReleaseWithoutDelete_throwsLockNotGrantedExceptionAndDoesNotUpdateDynamoDbAgain() {
+        UUID uuid = setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        long lastUpdatedTimeInMilliseconds = LockClientUtils.INSTANCE.millisecondTime();
+        LockItem item = new LockItem(client, "a", Optional.empty(), Optional.of(ByteBuffer.wrap("data".getBytes())),
+            false, uuid.toString(), 10000L, lastUpdatedTimeInMilliseconds,
+            "rvn", false, Optional.empty(), null);
+
+        assertTrue(client.releaseLock(ReleaseLockOptions.builder(item).withDeleteLock(false).build()));
+        assertTrue(item.isReleased());
+
+        try {
+            client.sendHeartbeat(SendHeartbeatOptions.builder(item).build());
+            fail("expected LockNotGrantedException");
+        } catch (LockNotGrantedException expected) {
+        }
+
+        verify(dynamodb, times(1)).updateItem(ArgumentMatchers.<UpdateItemRequest>any());
+    }
+
+    @Test
+    public void close_whenReleasingOneLockFails_releasesRemainingLocks() throws Exception {
+        setOwnerNameToUuid();
+        AmazonDynamoDBLockClient client = getLockClient();
+        when(dynamodb.getItem(ArgumentMatchers.<GetItemRequest>any())).thenReturn(GetItemResponse.builder().build());
+        client.acquireLock(AcquireLockOptions.builder("lock1").build());
+        client.acquireLock(AcquireLockOptions.builder("lock2").build());
+
+        when(dynamodb.deleteItem(ArgumentMatchers.<DeleteItemRequest>any()))
+            .thenThrow(SdkClientException.builder().message("network failure").build())
+            .thenReturn(null);
+
+        client.close();
+
+        verify(dynamodb, times(2)).deleteItem(ArgumentMatchers.<DeleteItemRequest>any());
+    }
+
+    @Test
+    public void sendHeartbeat_whenLockIsExpired_stopsSessionMonitorThread() throws Exception {
+        setOwnerNameToUuid();
+        List<Thread> createdThreads = new ArrayList<>();
+        AmazonDynamoDBLockClient client = new AmazonDynamoDBLockClient(
+            getLockClientBuilder(recordingThreadCreator(createdThreads)).build());
+        when(dynamodb.getItem(ArgumentMatchers.<GetItemRequest>any())).thenReturn(GetItemResponse.builder().build());
+        LockItem lockItem = client.acquireLock(sessionMonitorOptions());
+
+        assertEquals(1, createdThreads.size());
+        Thread monitorThread = createdThreads.get(0);
+        assertTrue(monitorThread.isAlive());
+
+        lockItem.updateLookUpTime(LockClientUtils.INSTANCE.millisecondTime() - 20000L); //lease duration is 10000 ms
+        try {
+            client.sendHeartbeat(lockItem);
+            fail("expected LockNotGrantedException");
+        } catch (LockNotGrantedException expected) {
+        }
+
+        assertFalse(monitorThread.isAlive());
+        client.close();
+    }
+
+    @Test
+    public void sendHeartbeat_whenLockIsStolen_stopsSessionMonitorThread() throws Exception {
+        setOwnerNameToUuid();
+        List<Thread> createdThreads = new ArrayList<>();
+        AmazonDynamoDBLockClient client = new AmazonDynamoDBLockClient(
+            getLockClientBuilder(recordingThreadCreator(createdThreads)).build());
+        when(dynamodb.getItem(ArgumentMatchers.<GetItemRequest>any())).thenReturn(GetItemResponse.builder().build());
+        LockItem lockItem = client.acquireLock(sessionMonitorOptions());
+
+        assertEquals(1, createdThreads.size());
+        Thread monitorThread = createdThreads.get(0);
+        assertTrue(monitorThread.isAlive());
+
+        when(dynamodb.updateItem(ArgumentMatchers.<UpdateItemRequest>any()))
+            .thenThrow(ConditionalCheckFailedException.builder().message("stolen").build());
+        try {
+            client.sendHeartbeat(lockItem);
+            fail("expected LockNotGrantedException");
+        } catch (LockNotGrantedException expected) {
+        }
+
+        assertFalse(monitorThread.isAlive());
+        client.close();
+    }
+
+    @Test
+    public void acquireLock_whenReacquiringSameLock_stopsPreviousSessionMonitorThread() throws Exception {
+        setOwnerNameToUuid();
+        List<Thread> createdThreads = new ArrayList<>();
+        AmazonDynamoDBLockClient client = new AmazonDynamoDBLockClient(
+            getLockClientBuilder(recordingThreadCreator(createdThreads)).build());
+        when(dynamodb.getItem(ArgumentMatchers.<GetItemRequest>any())).thenReturn(GetItemResponse.builder().build());
+        client.acquireLock(sessionMonitorOptions());
+        client.acquireLock(sessionMonitorOptions());
+
+        assertEquals(2, createdThreads.size());
+        assertFalse("previous acquisition's session monitor should be stopped", createdThreads.get(0).isAlive());
+        assertTrue("current acquisition's session monitor should be running", createdThreads.get(1).isAlive());
+        client.close();
+    }
+
+    private static AcquireLockOptions sessionMonitorOptions() {
+        //safe time must be greater than the heartbeat period (3000 ms) and less than the lease duration (10000 ms)
+        return AcquireLockOptions.builder(PARTITION_KEY)
+            .withSessionMonitor(5000L, Optional.of(() -> {
+            }))
+            .withTimeUnit(TimeUnit.MILLISECONDS)
+            .build();
+    }
+
+    private static Function<String, ThreadFactory> recordingThreadCreator(final List<Thread> createdThreads) {
+        return threadName -> runnable -> {
+            final Thread thread = new Thread(runnable, threadName);
+            createdThreads.add(thread);
+            return thread;
+        };
     }
 
     private AmazonDynamoDBLockClient getLockClient() {


### PR DESCRIPTION
## Summary

This change fixes several lifecycle and heartbeat correctness issues in the DynamoDB lock client:

- Makes `close()` / `releaseAllLocks()` shutdown more reliable by releasing held locks independently, so one failing DynamoDB release does not skip remaining locks, and by ensuring heartbeat thread shutdown runs in a `finally` block. It also removes unnecessary synchronization around the local lock map copy.
- Fixes session monitor lifecycle handling by stopping monitors when heartbeat abandons expired or stolen locks, stopping any previous monitor before registering a new one on reacquire, self-cleaning monitors with `remove(key, value)`, and making `removeKillSessionMonitor` a single null-safe remove/check operation.
- Prevents release-then-heartbeat races by marking locally-held `LockItem`s as released after successful release, then rechecking released state inside `sendHeartbeat`'s `synchronized(lockItem)` block so a concurrent or later manual heartbeat cannot resurrect or revalidate a released acquisition.
- Makes `holdLockOnServiceUnavailable` handling null-safe for `AwsServiceException` instances without error details while preserving the intended HTTP 503 service-unavailable behavior.

## Testing

- `mvn clean test` — 108/108 unit tests pass.
- Added/updated targeted unit coverage for best-effort close/release behavior, session monitor cleanup/replacement, release-then-heartbeat prevention, and null-safe service-unavailable handling.
